### PR TITLE
chore: 最初の表示画面を投稿一覧にする

### DIFF
--- a/app-front/app/(tabs)/_layout.tsx
+++ b/app-front/app/(tabs)/_layout.tsx
@@ -27,7 +27,7 @@ export default function TabLayout() {
       }}
     >
       <Tabs.Screen
-        name="index"
+        name="posts"
         options={{
           title: "Home",
           tabBarIcon: ({ color }) => (
@@ -45,7 +45,7 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
-        name="posts"
+        name="index"
         options={{
           title: "Posts",
           tabBarIcon: ({ color }) => (

--- a/app-front/app/_layout.tsx
+++ b/app-front/app/_layout.tsx
@@ -30,7 +30,7 @@ function AuthSwitch() {
   useEffect(() => {
     if (!loading) {
       if (user) {
-        router.replace("/(tabs)");
+        router.replace("/(tabs)/posts");
       } else {
         router.replace("/(auth)");
       }


### PR DESCRIPTION
## Summary by Sourcery

Changes the initial screen of the app to the posts list. This is achieved by reordering the tabs and redirecting authenticated users to the posts tab.

Chores:
- Change the initial screen of the app to the posts list.
- Reorder the tabs so that 'posts' is the first tab.
- Redirect authenticated users to the posts tab.