### PR TITLE
feat: petの画像でsignedUrlを利用

### DIFF
--- a/backend-go/Makefile
+++ b/backend-go/Makefile
@@ -1,4 +1,7 @@
-.PHONY: 
+include .env
+export
+
+.PHONY: run seed build up-db down-db psql
 
 run: up-db
 	go run cmd/api/main.go
@@ -14,3 +17,6 @@ up-db:
 
 down-db:
 	docker compose down db
+
+psql:
+	psql ${DATABASE_URL}

--- a/backend-go/Makefile
+++ b/backend-go/Makefile
@@ -11,3 +11,6 @@ build:
 
 up-db:
 	docker compose up db -d
+
+down-db:
+	docker compose down db

--- a/backend-go/internal/models/models.go
+++ b/backend-go/internal/models/models.go
@@ -61,7 +61,7 @@ type Pet struct {
 	BirthDay  string    `json:"birthDay"`
 	Type      PetType   `json:"type" gorm:"type:pet_type"`
 	Species   string    `json:"species" gorm:"type:pet_species"`
-	ImageURL  string    `json:"imageUrl"`
+	ImageKey  string   `json:"imageKey"`
 	OwnerID   string    `json:"ownerId"`
 	Owner     User      `json:"owner,omitempty" gorm:"foreignKey:OwnerID"`
 	CreatedAt time.Time `json:"createdAt" gorm:"autoCreateTime"`

--- a/backend-go/internal/models/responses/pet_response.go
+++ b/backend-go/internal/models/responses/pet_response.go
@@ -1,0 +1,35 @@
+package responses
+
+import (
+	"time"
+
+	"github.com/htanos/animalia/backend-go/internal/models"
+)
+
+// PetResponse represents the API response structure for a pet
+type PetResponse struct {
+	ID        string         `json:"id"`
+	Name      string         `json:"name"`
+	BirthDay  string         `json:"birthDay"`
+	Type      models.PetType `json:"type"`
+	Species   string         `json:"species"`
+	ImageURL  string        `json:"imageUrl"`
+	OwnerID   string         `json:"ownerId"`
+	Owner     models.User    `json:"owner,omitempty"`
+	CreatedAt time.Time      `json:"createdAt"`
+}
+
+// NewPetResponse converts a Pet to a PetResponse
+func NewPetResponse(pet *models.Pet, imageURL string) PetResponse {
+	return PetResponse{
+		ID:        pet.ID,
+		Name:      pet.Name,
+		BirthDay:  pet.BirthDay,
+		Type:      pet.Type,
+		Species:   pet.Species,
+		ImageURL:  imageURL,
+		OwnerID:   pet.OwnerID,
+		Owner:     pet.Owner,
+		CreatedAt: pet.CreatedAt,
+	}
+}

--- a/backend-go/internal/seed/data.go
+++ b/backend-go/internal/seed/data.go
@@ -55,7 +55,7 @@ func PetData(users []models.User) []models.Pet {
 			BirthDay: "2023-01-15",
 			Type:     "dog",
 			Species:  "saluki",
-			ImageKey: "",
+			ImageKey: "pets/26c4d55c-c16b-49b7-a4ef-5daa6ef2777f-BAB51C25-2C0A-4EC9-B7F5-96CAE90B0C48.jpg",
 			OwnerID:  users[0].ID, // John's pet
 		},
 		{
@@ -64,7 +64,7 @@ func PetData(users []models.User) []models.Pet {
 			BirthDay: "2022-05-10",
 			Type:     "cat",
 			Species:  "siamese",
-			ImageKey: "",
+			ImageKey: "pets/26c4d55c-c16b-49b7-a4ef-5daa6ef2777f-BAB51C25-2C0A-4EC9-B7F5-96CAE90B0C48.jpg",
 			OwnerID:  users[1].ID, // Jane's pet
 		},
 		{
@@ -73,7 +73,7 @@ func PetData(users []models.User) []models.Pet {
 			BirthDay: "2021-11-22",
 			Type:     "dog",
 			Species:  "beagle",
-			ImageKey: "",
+			ImageKey: "pets/26c4d55c-c16b-49b7-a4ef-5daa6ef2777f-BAB51C25-2C0A-4EC9-B7F5-96CAE90B0C48.jpg",
 			OwnerID:  users[2].ID, // Alex's pet
 		},
 		{
@@ -82,7 +82,7 @@ func PetData(users []models.User) []models.Pet {
 			BirthDay: "2023-03-05",
 			Type:     "dog",
 			Species:  "poodle",
-			ImageKey: "",
+			ImageKey: "pets/26c4d55c-c16b-49b7-a4ef-5daa6ef2777f-BAB51C25-2C0A-4EC9-B7F5-96CAE90B0C48.jpg",
 			OwnerID:  users[3].ID, // Emily's pet
 		},
 		{
@@ -91,7 +91,7 @@ func PetData(users []models.User) []models.Pet {
 			BirthDay: "2022-08-17",
 			Type:     "dog",
 			Species:  "golden_retriever",
-			ImageKey: "",
+			ImageKey: "pets/26c4d55c-c16b-49b7-a4ef-5daa6ef2777f-BAB51C25-2C0A-4EC9-B7F5-96CAE90B0C48.jpg",
 			OwnerID:  users[4].ID, // Michael's pet
 		},
 		{
@@ -100,7 +100,7 @@ func PetData(users []models.User) []models.Pet {
 			BirthDay: "2023-02-28",
 			Type:     "cat",
 			Species:  "munchkin",
-			ImageKey: "",
+			ImageKey: "pets/26c4d55c-c16b-49b7-a4ef-5daa6ef2777f-BAB51C25-2C0A-4EC9-B7F5-96CAE90B0C48.jpg",
 			OwnerID:  users[0].ID, // John's second pet
 		},
 	}

--- a/backend-go/internal/seed/data.go
+++ b/backend-go/internal/seed/data.go
@@ -55,7 +55,7 @@ func PetData(users []models.User) []models.Pet {
 			BirthDay: "2023-01-15",
 			Type:     "dog",
 			Species:  "saluki",
-			ImageURL: "https://example.com/images/max.jpg",
+			ImageKey: "",
 			OwnerID:  users[0].ID, // John's pet
 		},
 		{
@@ -64,7 +64,7 @@ func PetData(users []models.User) []models.Pet {
 			BirthDay: "2022-05-10",
 			Type:     "cat",
 			Species:  "siamese",
-			ImageURL: "https://example.com/images/luna.jpg",
+			ImageKey: "",
 			OwnerID:  users[1].ID, // Jane's pet
 		},
 		{
@@ -73,7 +73,7 @@ func PetData(users []models.User) []models.Pet {
 			BirthDay: "2021-11-22",
 			Type:     "dog",
 			Species:  "beagle",
-			ImageURL: "https://example.com/images/buddy.jpg",
+			ImageKey: "",
 			OwnerID:  users[2].ID, // Alex's pet
 		},
 		{
@@ -82,7 +82,7 @@ func PetData(users []models.User) []models.Pet {
 			BirthDay: "2023-03-05",
 			Type:     "dog",
 			Species:  "poodle",
-			ImageURL: "https://example.com/images/coco.jpg",
+			ImageKey: "",
 			OwnerID:  users[3].ID, // Emily's pet
 		},
 		{
@@ -91,7 +91,7 @@ func PetData(users []models.User) []models.Pet {
 			BirthDay: "2022-08-17",
 			Type:     "dog",
 			Species:  "golden_retriever",
-			ImageURL: "https://example.com/images/rocky.jpg",
+			ImageKey: "",
 			OwnerID:  users[4].ID, // Michael's pet
 		},
 		{
@@ -100,7 +100,7 @@ func PetData(users []models.User) []models.Pet {
 			BirthDay: "2023-02-28",
 			Type:     "cat",
 			Species:  "munchkin",
-			ImageURL: "https://example.com/images/milo.jpg",
+			ImageKey: "",
 			OwnerID:  users[0].ID, // John's second pet
 		},
 	}


### PR DESCRIPTION
## Summary by Sourcery

Updates the pet image handling to use signed URLs for enhanced security and efficiency. This involves storing the image key instead of the full URL in the database and generating signed URLs on demand.

Enhancements:
- Replaces direct S3 URLs with signed URLs for pet images, improving security.
- Updates the database to store image keys instead of full URLs.
- Introduces a new PetResponse struct to handle the signed image URL.
- Adds a utility function to generate signed URLs for S3 objects.