### PR TITLE
chore: gitのrepository nameを変更

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ run: build
 run-attach: build
 	docker compose up api
 
-run-seed:
+run-seed: build
 	SEED=true docker compose up api -d
 
 build:

--- a/backend-go/cmd/api/main.go
+++ b/backend-go/cmd/api/main.go
@@ -5,12 +5,12 @@ import (
 	"log"
 	"os"
 
+	"github.com/aki-13627/animalia/backend-go/ent"
+	"github.com/aki-13627/animalia/backend-go/internal/routes"
+	"github.com/aki-13627/animalia/backend-go/internal/seed"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/cors"
 	"github.com/gofiber/fiber/v2/middleware/logger"
-	"github.com/htanos/animalia/backend-go/ent"
-	"github.com/htanos/animalia/backend-go/internal/routes"
-	"github.com/htanos/animalia/backend-go/internal/seed"
 	"github.com/joho/godotenv"
 	"github.com/rs/zerolog"
 )

--- a/backend-go/ent/client.go
+++ b/backend-go/ent/client.go
@@ -9,19 +9,19 @@ import (
 	"log"
 	"reflect"
 
+	"github.com/aki-13627/animalia/backend-go/ent/migrate"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/migrate"
 
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
-	"github.com/htanos/animalia/backend-go/ent/comment"
-	"github.com/htanos/animalia/backend-go/ent/followrelation"
-	"github.com/htanos/animalia/backend-go/ent/like"
-	"github.com/htanos/animalia/backend-go/ent/pet"
-	"github.com/htanos/animalia/backend-go/ent/post"
-	"github.com/htanos/animalia/backend-go/ent/user"
+	"github.com/aki-13627/animalia/backend-go/ent/comment"
+	"github.com/aki-13627/animalia/backend-go/ent/followrelation"
+	"github.com/aki-13627/animalia/backend-go/ent/like"
+	"github.com/aki-13627/animalia/backend-go/ent/pet"
+	"github.com/aki-13627/animalia/backend-go/ent/post"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 )
 
 // Client is the client that holds all ent builders.

--- a/backend-go/ent/comment.go
+++ b/backend-go/ent/comment.go
@@ -9,10 +9,10 @@ import (
 
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
+	"github.com/aki-13627/animalia/backend-go/ent/comment"
+	"github.com/aki-13627/animalia/backend-go/ent/post"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/comment"
-	"github.com/htanos/animalia/backend-go/ent/post"
-	"github.com/htanos/animalia/backend-go/ent/user"
 )
 
 // Comment is the model entity for the Comment schema.

--- a/backend-go/ent/comment/where.go
+++ b/backend-go/ent/comment/where.go
@@ -7,8 +7,8 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
+	"github.com/aki-13627/animalia/backend-go/ent/predicate"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/predicate"
 )
 
 // ID filters vertices based on their ID field.

--- a/backend-go/ent/comment_create.go
+++ b/backend-go/ent/comment_create.go
@@ -12,10 +12,10 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/aki-13627/animalia/backend-go/ent/comment"
+	"github.com/aki-13627/animalia/backend-go/ent/post"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/comment"
-	"github.com/htanos/animalia/backend-go/ent/post"
-	"github.com/htanos/animalia/backend-go/ent/user"
 )
 
 // CommentCreate is the builder for creating a Comment entity.

--- a/backend-go/ent/comment_delete.go
+++ b/backend-go/ent/comment_delete.go
@@ -8,8 +8,8 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
-	"github.com/htanos/animalia/backend-go/ent/comment"
-	"github.com/htanos/animalia/backend-go/ent/predicate"
+	"github.com/aki-13627/animalia/backend-go/ent/comment"
+	"github.com/aki-13627/animalia/backend-go/ent/predicate"
 )
 
 // CommentDelete is the builder for deleting a Comment entity.

--- a/backend-go/ent/comment_query.go
+++ b/backend-go/ent/comment_query.go
@@ -11,11 +11,11 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/aki-13627/animalia/backend-go/ent/comment"
+	"github.com/aki-13627/animalia/backend-go/ent/post"
+	"github.com/aki-13627/animalia/backend-go/ent/predicate"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/comment"
-	"github.com/htanos/animalia/backend-go/ent/post"
-	"github.com/htanos/animalia/backend-go/ent/predicate"
-	"github.com/htanos/animalia/backend-go/ent/user"
 )
 
 // CommentQuery is the builder for querying Comment entities.

--- a/backend-go/ent/comment_update.go
+++ b/backend-go/ent/comment_update.go
@@ -11,11 +11,11 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/aki-13627/animalia/backend-go/ent/comment"
+	"github.com/aki-13627/animalia/backend-go/ent/post"
+	"github.com/aki-13627/animalia/backend-go/ent/predicate"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/comment"
-	"github.com/htanos/animalia/backend-go/ent/post"
-	"github.com/htanos/animalia/backend-go/ent/predicate"
-	"github.com/htanos/animalia/backend-go/ent/user"
 )
 
 // CommentUpdate is the builder for updating Comment entities.

--- a/backend-go/ent/ent.go
+++ b/backend-go/ent/ent.go
@@ -12,12 +12,12 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
-	"github.com/htanos/animalia/backend-go/ent/comment"
-	"github.com/htanos/animalia/backend-go/ent/followrelation"
-	"github.com/htanos/animalia/backend-go/ent/like"
-	"github.com/htanos/animalia/backend-go/ent/pet"
-	"github.com/htanos/animalia/backend-go/ent/post"
-	"github.com/htanos/animalia/backend-go/ent/user"
+	"github.com/aki-13627/animalia/backend-go/ent/comment"
+	"github.com/aki-13627/animalia/backend-go/ent/followrelation"
+	"github.com/aki-13627/animalia/backend-go/ent/like"
+	"github.com/aki-13627/animalia/backend-go/ent/pet"
+	"github.com/aki-13627/animalia/backend-go/ent/post"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 )
 
 // ent aliases to avoid import conflicts in user's code.

--- a/backend-go/ent/enttest/enttest.go
+++ b/backend-go/ent/enttest/enttest.go
@@ -5,12 +5,12 @@ package enttest
 import (
 	"context"
 
-	"github.com/htanos/animalia/backend-go/ent"
+	"github.com/aki-13627/animalia/backend-go/ent"
 	// required by schema hooks.
-	_ "github.com/htanos/animalia/backend-go/ent/runtime"
+	_ "github.com/aki-13627/animalia/backend-go/ent/runtime"
 
 	"entgo.io/ent/dialect/sql/schema"
-	"github.com/htanos/animalia/backend-go/ent/migrate"
+	"github.com/aki-13627/animalia/backend-go/ent/migrate"
 )
 
 type (

--- a/backend-go/ent/followrelation.go
+++ b/backend-go/ent/followrelation.go
@@ -9,9 +9,9 @@ import (
 
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
+	"github.com/aki-13627/animalia/backend-go/ent/followrelation"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/followrelation"
-	"github.com/htanos/animalia/backend-go/ent/user"
 )
 
 // FollowRelation is the model entity for the FollowRelation schema.

--- a/backend-go/ent/followrelation/where.go
+++ b/backend-go/ent/followrelation/where.go
@@ -7,8 +7,8 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
+	"github.com/aki-13627/animalia/backend-go/ent/predicate"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/predicate"
 )
 
 // ID filters vertices based on their ID field.

--- a/backend-go/ent/followrelation_create.go
+++ b/backend-go/ent/followrelation_create.go
@@ -12,9 +12,9 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/aki-13627/animalia/backend-go/ent/followrelation"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/followrelation"
-	"github.com/htanos/animalia/backend-go/ent/user"
 )
 
 // FollowRelationCreate is the builder for creating a FollowRelation entity.

--- a/backend-go/ent/followrelation_delete.go
+++ b/backend-go/ent/followrelation_delete.go
@@ -8,8 +8,8 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
-	"github.com/htanos/animalia/backend-go/ent/followrelation"
-	"github.com/htanos/animalia/backend-go/ent/predicate"
+	"github.com/aki-13627/animalia/backend-go/ent/followrelation"
+	"github.com/aki-13627/animalia/backend-go/ent/predicate"
 )
 
 // FollowRelationDelete is the builder for deleting a FollowRelation entity.

--- a/backend-go/ent/followrelation_query.go
+++ b/backend-go/ent/followrelation_query.go
@@ -11,10 +11,10 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/aki-13627/animalia/backend-go/ent/followrelation"
+	"github.com/aki-13627/animalia/backend-go/ent/predicate"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/followrelation"
-	"github.com/htanos/animalia/backend-go/ent/predicate"
-	"github.com/htanos/animalia/backend-go/ent/user"
 )
 
 // FollowRelationQuery is the builder for querying FollowRelation entities.

--- a/backend-go/ent/followrelation_update.go
+++ b/backend-go/ent/followrelation_update.go
@@ -11,10 +11,10 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/aki-13627/animalia/backend-go/ent/followrelation"
+	"github.com/aki-13627/animalia/backend-go/ent/predicate"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/followrelation"
-	"github.com/htanos/animalia/backend-go/ent/predicate"
-	"github.com/htanos/animalia/backend-go/ent/user"
 )
 
 // FollowRelationUpdate is the builder for updating FollowRelation entities.

--- a/backend-go/ent/hook/hook.go
+++ b/backend-go/ent/hook/hook.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/htanos/animalia/backend-go/ent"
+	"github.com/aki-13627/animalia/backend-go/ent"
 )
 
 // The CommentFunc type is an adapter to allow the use of ordinary

--- a/backend-go/ent/like.go
+++ b/backend-go/ent/like.go
@@ -9,10 +9,10 @@ import (
 
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
+	"github.com/aki-13627/animalia/backend-go/ent/like"
+	"github.com/aki-13627/animalia/backend-go/ent/post"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/like"
-	"github.com/htanos/animalia/backend-go/ent/post"
-	"github.com/htanos/animalia/backend-go/ent/user"
 )
 
 // Like is the model entity for the Like schema.

--- a/backend-go/ent/like/where.go
+++ b/backend-go/ent/like/where.go
@@ -7,8 +7,8 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
+	"github.com/aki-13627/animalia/backend-go/ent/predicate"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/predicate"
 )
 
 // ID filters vertices based on their ID field.

--- a/backend-go/ent/like_create.go
+++ b/backend-go/ent/like_create.go
@@ -12,10 +12,10 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/aki-13627/animalia/backend-go/ent/like"
+	"github.com/aki-13627/animalia/backend-go/ent/post"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/like"
-	"github.com/htanos/animalia/backend-go/ent/post"
-	"github.com/htanos/animalia/backend-go/ent/user"
 )
 
 // LikeCreate is the builder for creating a Like entity.

--- a/backend-go/ent/like_delete.go
+++ b/backend-go/ent/like_delete.go
@@ -8,8 +8,8 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
-	"github.com/htanos/animalia/backend-go/ent/like"
-	"github.com/htanos/animalia/backend-go/ent/predicate"
+	"github.com/aki-13627/animalia/backend-go/ent/like"
+	"github.com/aki-13627/animalia/backend-go/ent/predicate"
 )
 
 // LikeDelete is the builder for deleting a Like entity.

--- a/backend-go/ent/like_query.go
+++ b/backend-go/ent/like_query.go
@@ -11,11 +11,11 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/aki-13627/animalia/backend-go/ent/like"
+	"github.com/aki-13627/animalia/backend-go/ent/post"
+	"github.com/aki-13627/animalia/backend-go/ent/predicate"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/like"
-	"github.com/htanos/animalia/backend-go/ent/post"
-	"github.com/htanos/animalia/backend-go/ent/predicate"
-	"github.com/htanos/animalia/backend-go/ent/user"
 )
 
 // LikeQuery is the builder for querying Like entities.

--- a/backend-go/ent/like_update.go
+++ b/backend-go/ent/like_update.go
@@ -11,11 +11,11 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/aki-13627/animalia/backend-go/ent/like"
+	"github.com/aki-13627/animalia/backend-go/ent/post"
+	"github.com/aki-13627/animalia/backend-go/ent/predicate"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/like"
-	"github.com/htanos/animalia/backend-go/ent/post"
-	"github.com/htanos/animalia/backend-go/ent/predicate"
-	"github.com/htanos/animalia/backend-go/ent/user"
 )
 
 // LikeUpdate is the builder for updating Like entities.

--- a/backend-go/ent/mutation.go
+++ b/backend-go/ent/mutation.go
@@ -11,14 +11,14 @@ import (
 
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
+	"github.com/aki-13627/animalia/backend-go/ent/comment"
+	"github.com/aki-13627/animalia/backend-go/ent/followrelation"
+	"github.com/aki-13627/animalia/backend-go/ent/like"
+	"github.com/aki-13627/animalia/backend-go/ent/pet"
+	"github.com/aki-13627/animalia/backend-go/ent/post"
+	"github.com/aki-13627/animalia/backend-go/ent/predicate"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/comment"
-	"github.com/htanos/animalia/backend-go/ent/followrelation"
-	"github.com/htanos/animalia/backend-go/ent/like"
-	"github.com/htanos/animalia/backend-go/ent/pet"
-	"github.com/htanos/animalia/backend-go/ent/post"
-	"github.com/htanos/animalia/backend-go/ent/predicate"
-	"github.com/htanos/animalia/backend-go/ent/user"
 	pgvector "github.com/pgvector/pgvector-go"
 )
 

--- a/backend-go/ent/pet.go
+++ b/backend-go/ent/pet.go
@@ -9,9 +9,9 @@ import (
 
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
+	"github.com/aki-13627/animalia/backend-go/ent/pet"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/pet"
-	"github.com/htanos/animalia/backend-go/ent/user"
 )
 
 // Pet is the model entity for the Pet schema.

--- a/backend-go/ent/pet/where.go
+++ b/backend-go/ent/pet/where.go
@@ -7,8 +7,8 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
+	"github.com/aki-13627/animalia/backend-go/ent/predicate"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/predicate"
 )
 
 // ID filters vertices based on their ID field.

--- a/backend-go/ent/pet_create.go
+++ b/backend-go/ent/pet_create.go
@@ -12,9 +12,9 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/aki-13627/animalia/backend-go/ent/pet"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/pet"
-	"github.com/htanos/animalia/backend-go/ent/user"
 )
 
 // PetCreate is the builder for creating a Pet entity.

--- a/backend-go/ent/pet_delete.go
+++ b/backend-go/ent/pet_delete.go
@@ -8,8 +8,8 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
-	"github.com/htanos/animalia/backend-go/ent/pet"
-	"github.com/htanos/animalia/backend-go/ent/predicate"
+	"github.com/aki-13627/animalia/backend-go/ent/pet"
+	"github.com/aki-13627/animalia/backend-go/ent/predicate"
 )
 
 // PetDelete is the builder for deleting a Pet entity.

--- a/backend-go/ent/pet_query.go
+++ b/backend-go/ent/pet_query.go
@@ -11,10 +11,10 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/aki-13627/animalia/backend-go/ent/pet"
+	"github.com/aki-13627/animalia/backend-go/ent/predicate"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/pet"
-	"github.com/htanos/animalia/backend-go/ent/predicate"
-	"github.com/htanos/animalia/backend-go/ent/user"
 )
 
 // PetQuery is the builder for querying Pet entities.

--- a/backend-go/ent/pet_update.go
+++ b/backend-go/ent/pet_update.go
@@ -11,10 +11,10 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/aki-13627/animalia/backend-go/ent/pet"
+	"github.com/aki-13627/animalia/backend-go/ent/predicate"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/pet"
-	"github.com/htanos/animalia/backend-go/ent/predicate"
-	"github.com/htanos/animalia/backend-go/ent/user"
 )
 
 // PetUpdate is the builder for updating Pet entities.

--- a/backend-go/ent/post.go
+++ b/backend-go/ent/post.go
@@ -9,9 +9,9 @@ import (
 
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
+	"github.com/aki-13627/animalia/backend-go/ent/post"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/post"
-	"github.com/htanos/animalia/backend-go/ent/user"
 	pgvector "github.com/pgvector/pgvector-go"
 )
 

--- a/backend-go/ent/post/where.go
+++ b/backend-go/ent/post/where.go
@@ -7,8 +7,8 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
+	"github.com/aki-13627/animalia/backend-go/ent/predicate"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/predicate"
 	pgvector "github.com/pgvector/pgvector-go"
 )
 

--- a/backend-go/ent/post_create.go
+++ b/backend-go/ent/post_create.go
@@ -12,11 +12,11 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/aki-13627/animalia/backend-go/ent/comment"
+	"github.com/aki-13627/animalia/backend-go/ent/like"
+	"github.com/aki-13627/animalia/backend-go/ent/post"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/comment"
-	"github.com/htanos/animalia/backend-go/ent/like"
-	"github.com/htanos/animalia/backend-go/ent/post"
-	"github.com/htanos/animalia/backend-go/ent/user"
 	pgvector "github.com/pgvector/pgvector-go"
 )
 

--- a/backend-go/ent/post_delete.go
+++ b/backend-go/ent/post_delete.go
@@ -8,8 +8,8 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
-	"github.com/htanos/animalia/backend-go/ent/post"
-	"github.com/htanos/animalia/backend-go/ent/predicate"
+	"github.com/aki-13627/animalia/backend-go/ent/post"
+	"github.com/aki-13627/animalia/backend-go/ent/predicate"
 )
 
 // PostDelete is the builder for deleting a Post entity.

--- a/backend-go/ent/post_query.go
+++ b/backend-go/ent/post_query.go
@@ -12,12 +12,12 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/aki-13627/animalia/backend-go/ent/comment"
+	"github.com/aki-13627/animalia/backend-go/ent/like"
+	"github.com/aki-13627/animalia/backend-go/ent/post"
+	"github.com/aki-13627/animalia/backend-go/ent/predicate"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/comment"
-	"github.com/htanos/animalia/backend-go/ent/like"
-	"github.com/htanos/animalia/backend-go/ent/post"
-	"github.com/htanos/animalia/backend-go/ent/predicate"
-	"github.com/htanos/animalia/backend-go/ent/user"
 )
 
 // PostQuery is the builder for querying Post entities.

--- a/backend-go/ent/post_update.go
+++ b/backend-go/ent/post_update.go
@@ -11,12 +11,12 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/aki-13627/animalia/backend-go/ent/comment"
+	"github.com/aki-13627/animalia/backend-go/ent/like"
+	"github.com/aki-13627/animalia/backend-go/ent/post"
+	"github.com/aki-13627/animalia/backend-go/ent/predicate"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/comment"
-	"github.com/htanos/animalia/backend-go/ent/like"
-	"github.com/htanos/animalia/backend-go/ent/post"
-	"github.com/htanos/animalia/backend-go/ent/predicate"
-	"github.com/htanos/animalia/backend-go/ent/user"
 	pgvector "github.com/pgvector/pgvector-go"
 )
 

--- a/backend-go/ent/runtime.go
+++ b/backend-go/ent/runtime.go
@@ -5,14 +5,14 @@ package ent
 import (
 	"time"
 
+	"github.com/aki-13627/animalia/backend-go/ent/comment"
+	"github.com/aki-13627/animalia/backend-go/ent/followrelation"
+	"github.com/aki-13627/animalia/backend-go/ent/like"
+	"github.com/aki-13627/animalia/backend-go/ent/pet"
+	"github.com/aki-13627/animalia/backend-go/ent/post"
+	"github.com/aki-13627/animalia/backend-go/ent/schema"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/comment"
-	"github.com/htanos/animalia/backend-go/ent/followrelation"
-	"github.com/htanos/animalia/backend-go/ent/like"
-	"github.com/htanos/animalia/backend-go/ent/pet"
-	"github.com/htanos/animalia/backend-go/ent/post"
-	"github.com/htanos/animalia/backend-go/ent/schema"
-	"github.com/htanos/animalia/backend-go/ent/user"
 )
 
 // The init function reads all schema descriptors with runtime code

--- a/backend-go/ent/runtime/runtime.go
+++ b/backend-go/ent/runtime/runtime.go
@@ -2,7 +2,7 @@
 
 package runtime
 
-// The schema-stitching logic is generated in github.com/htanos/animalia/backend-go/ent/runtime.go
+// The schema-stitching logic is generated in github.com/aki-13627/animalia/backend-go/ent/runtime.go
 
 const (
 	Version = "v0.14.4"                                         // Version of ent codegen.

--- a/backend-go/ent/user.go
+++ b/backend-go/ent/user.go
@@ -9,8 +9,8 @@ import (
 
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/user"
 )
 
 // User is the model entity for the User schema.

--- a/backend-go/ent/user/where.go
+++ b/backend-go/ent/user/where.go
@@ -7,8 +7,8 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
+	"github.com/aki-13627/animalia/backend-go/ent/predicate"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/predicate"
 )
 
 // ID filters vertices based on their ID field.

--- a/backend-go/ent/user_create.go
+++ b/backend-go/ent/user_create.go
@@ -12,13 +12,13 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/aki-13627/animalia/backend-go/ent/comment"
+	"github.com/aki-13627/animalia/backend-go/ent/followrelation"
+	"github.com/aki-13627/animalia/backend-go/ent/like"
+	"github.com/aki-13627/animalia/backend-go/ent/pet"
+	"github.com/aki-13627/animalia/backend-go/ent/post"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/comment"
-	"github.com/htanos/animalia/backend-go/ent/followrelation"
-	"github.com/htanos/animalia/backend-go/ent/like"
-	"github.com/htanos/animalia/backend-go/ent/pet"
-	"github.com/htanos/animalia/backend-go/ent/post"
-	"github.com/htanos/animalia/backend-go/ent/user"
 )
 
 // UserCreate is the builder for creating a User entity.

--- a/backend-go/ent/user_delete.go
+++ b/backend-go/ent/user_delete.go
@@ -8,8 +8,8 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
-	"github.com/htanos/animalia/backend-go/ent/predicate"
-	"github.com/htanos/animalia/backend-go/ent/user"
+	"github.com/aki-13627/animalia/backend-go/ent/predicate"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 )
 
 // UserDelete is the builder for deleting a User entity.

--- a/backend-go/ent/user_query.go
+++ b/backend-go/ent/user_query.go
@@ -12,14 +12,14 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/aki-13627/animalia/backend-go/ent/comment"
+	"github.com/aki-13627/animalia/backend-go/ent/followrelation"
+	"github.com/aki-13627/animalia/backend-go/ent/like"
+	"github.com/aki-13627/animalia/backend-go/ent/pet"
+	"github.com/aki-13627/animalia/backend-go/ent/post"
+	"github.com/aki-13627/animalia/backend-go/ent/predicate"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/comment"
-	"github.com/htanos/animalia/backend-go/ent/followrelation"
-	"github.com/htanos/animalia/backend-go/ent/like"
-	"github.com/htanos/animalia/backend-go/ent/pet"
-	"github.com/htanos/animalia/backend-go/ent/post"
-	"github.com/htanos/animalia/backend-go/ent/predicate"
-	"github.com/htanos/animalia/backend-go/ent/user"
 )
 
 // UserQuery is the builder for querying User entities.

--- a/backend-go/ent/user_update.go
+++ b/backend-go/ent/user_update.go
@@ -11,14 +11,14 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/aki-13627/animalia/backend-go/ent/comment"
+	"github.com/aki-13627/animalia/backend-go/ent/followrelation"
+	"github.com/aki-13627/animalia/backend-go/ent/like"
+	"github.com/aki-13627/animalia/backend-go/ent/pet"
+	"github.com/aki-13627/animalia/backend-go/ent/post"
+	"github.com/aki-13627/animalia/backend-go/ent/predicate"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent/comment"
-	"github.com/htanos/animalia/backend-go/ent/followrelation"
-	"github.com/htanos/animalia/backend-go/ent/like"
-	"github.com/htanos/animalia/backend-go/ent/pet"
-	"github.com/htanos/animalia/backend-go/ent/post"
-	"github.com/htanos/animalia/backend-go/ent/predicate"
-	"github.com/htanos/animalia/backend-go/ent/user"
 )
 
 // UserUpdate is the builder for updating User entities.

--- a/backend-go/go.mod
+++ b/backend-go/go.mod
@@ -1,4 +1,4 @@
-module github.com/htanos/animalia/backend-go
+module github.com/aki-13627/animalia/backend-go
 
 go 1.23.0
 

--- a/backend-go/go.mod
+++ b/backend-go/go.mod
@@ -18,6 +18,8 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pgvector/pgvector-go v0.3.0
 	github.com/rs/zerolog v1.34.0
+	github.com/spf13/cobra v1.7.0
+	github.com/spf13/pflag v1.0.5
 )
 
 require (
@@ -45,6 +47,7 @@ require (
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/hashicorp/hcl/v2 v2.23.0 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/klauspost/compress v1.17.6 // indirect
 	github.com/lestrrat-go/backoff/v2 v2.0.8 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.2 // indirect

--- a/backend-go/go.sum
+++ b/backend-go/go.sum
@@ -139,6 +139,10 @@ github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUc
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
 github.com/rs/zerolog v1.34.0 h1:k43nTLIwcTVQAncfCw4KZ2VY6ukYoZaBPNOE8txlOeY=
 github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6wYQ=
+github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
+github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/backend-go/go.sum
+++ b/backend-go/go.sum
@@ -51,6 +51,7 @@ github.com/aws/smithy-go v1.20.1/go.mod h1:krry+ya/rV9RDcV/Q16kpu6ypI4K2czasz0NC
 github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=
 github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -78,6 +79,8 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/hcl/v2 v2.23.0 h1:Fphj1/gCylPxHutVSEOf2fBOh1VE4AuLV7+kbJf3qos=
 github.com/hashicorp/hcl/v2 v2.23.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
@@ -139,6 +142,7 @@ github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUc
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
 github.com/rs/zerolog v1.34.0 h1:k43nTLIwcTVQAncfCw4KZ2VY6ukYoZaBPNOE8txlOeY=
 github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6wYQ=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
 github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/backend-go/internal/domain/models/auth.go
+++ b/backend-go/internal/domain/models/auth.go
@@ -1,8 +1,8 @@
 package models
 
 import (
+	"github.com/aki-13627/animalia/backend-go/ent"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent"
 )
 
 type RefreshTokenResponse struct {

--- a/backend-go/internal/domain/models/pet.go
+++ b/backend-go/internal/domain/models/pet.go
@@ -3,9 +3,9 @@ package models
 import (
 	"time"
 
+	"github.com/aki-13627/animalia/backend-go/ent"
+	"github.com/aki-13627/animalia/backend-go/ent/pet"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent"
-	"github.com/htanos/animalia/backend-go/ent/pet"
 )
 
 // PetResponse represents the API response structure for a pet

--- a/backend-go/internal/domain/models/post.go
+++ b/backend-go/internal/domain/models/post.go
@@ -3,8 +3,8 @@ package models
 import (
 	"time"
 
+	"github.com/aki-13627/animalia/backend-go/ent"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent"
 )
 
 type PostResponse struct {

--- a/backend-go/internal/domain/repository/followrelation.go
+++ b/backend-go/internal/domain/repository/followrelation.go
@@ -1,6 +1,6 @@
 package repository
 
-import "github.com/htanos/animalia/backend-go/ent"
+import "github.com/aki-13627/animalia/backend-go/ent"
 
 type FollowRelationRepository interface {
 	CountFollows(userId string) (int, error)

--- a/backend-go/internal/domain/repository/pet.go
+++ b/backend-go/internal/domain/repository/pet.go
@@ -1,7 +1,7 @@
 package repository
 
 import (
-	"github.com/htanos/animalia/backend-go/ent"
+	"github.com/aki-13627/animalia/backend-go/ent"
 )
 
 type PetRepository interface {

--- a/backend-go/internal/domain/repository/post.go
+++ b/backend-go/internal/domain/repository/post.go
@@ -1,6 +1,6 @@
 package repository
 
-import "github.com/htanos/animalia/backend-go/ent"
+import "github.com/aki-13627/animalia/backend-go/ent"
 
 type PostRepository interface {
 	GetAllPosts() ([]*ent.Post, error)

--- a/backend-go/internal/domain/repository/user.go
+++ b/backend-go/internal/domain/repository/user.go
@@ -1,7 +1,7 @@
 package repository
 
 import (
-	"github.com/htanos/animalia/backend-go/ent"
+	"github.com/aki-13627/animalia/backend-go/ent"
 )
 
 type UserRepository interface {

--- a/backend-go/internal/handler/auth_handler.go
+++ b/backend-go/internal/handler/auth_handler.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/aki-13627/animalia/backend-go/internal/domain/models"
+	"github.com/aki-13627/animalia/backend-go/internal/usecase"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/log"
-	"github.com/htanos/animalia/backend-go/internal/domain/models"
-	"github.com/htanos/animalia/backend-go/internal/usecase"
 )
 
 type AuthHandler struct {

--- a/backend-go/internal/handler/pet_handler.go
+++ b/backend-go/internal/handler/pet_handler.go
@@ -1,10 +1,10 @@
 package handler
 
 import (
+	"github.com/aki-13627/animalia/backend-go/internal/domain/models"
+	"github.com/aki-13627/animalia/backend-go/internal/usecase"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/log"
-	"github.com/htanos/animalia/backend-go/internal/domain/models"
-	"github.com/htanos/animalia/backend-go/internal/usecase"
 )
 
 type PetHandler struct {

--- a/backend-go/internal/handler/post_handler.go
+++ b/backend-go/internal/handler/post_handler.go
@@ -1,10 +1,10 @@
 package handler
 
 import (
+	"github.com/aki-13627/animalia/backend-go/internal/domain/models"
+	"github.com/aki-13627/animalia/backend-go/internal/usecase"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/log"
-	"github.com/htanos/animalia/backend-go/internal/domain/models"
-	"github.com/htanos/animalia/backend-go/internal/usecase"
 )
 
 type PostHandler struct {

--- a/backend-go/internal/handler/user_handler.go
+++ b/backend-go/internal/handler/user_handler.go
@@ -1,9 +1,9 @@
 package handler
 
 import (
+	"github.com/aki-13627/animalia/backend-go/internal/usecase"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/log"
-	"github.com/htanos/animalia/backend-go/internal/usecase"
 )
 
 type UserHandler struct {

--- a/backend-go/internal/infra/followrelation.go
+++ b/backend-go/internal/infra/followrelation.go
@@ -3,10 +3,10 @@ package infra
 import (
 	"context"
 
+	"github.com/aki-13627/animalia/backend-go/ent"
+	"github.com/aki-13627/animalia/backend-go/ent/followrelation"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent"
-	"github.com/htanos/animalia/backend-go/ent/followrelation"
-	"github.com/htanos/animalia/backend-go/ent/user"
 )
 
 type FollowRelationRepository struct {

--- a/backend-go/internal/infra/pet.go
+++ b/backend-go/internal/infra/pet.go
@@ -3,10 +3,10 @@ package infra
 import (
 	"context"
 
+	"github.com/aki-13627/animalia/backend-go/ent"
+	"github.com/aki-13627/animalia/backend-go/ent/pet"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent"
-	"github.com/htanos/animalia/backend-go/ent/pet"
-	"github.com/htanos/animalia/backend-go/ent/user"
 )
 
 type PetRepository struct {

--- a/backend-go/internal/infra/post.go
+++ b/backend-go/internal/infra/post.go
@@ -3,10 +3,10 @@ package infra
 import (
 	"context"
 
+	"github.com/aki-13627/animalia/backend-go/ent"
+	"github.com/aki-13627/animalia/backend-go/ent/post"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent"
-	"github.com/htanos/animalia/backend-go/ent/post"
-	"github.com/htanos/animalia/backend-go/ent/user"
 )
 
 type PostRepository struct {

--- a/backend-go/internal/infra/user.go
+++ b/backend-go/internal/infra/user.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/aki-13627/animalia/backend-go/ent"
+	"github.com/aki-13627/animalia/backend-go/ent/user"
 	"github.com/google/uuid"
-	"github.com/htanos/animalia/backend-go/ent"
-	"github.com/htanos/animalia/backend-go/ent/user"
 )
 
 type UserRepository struct {
@@ -32,9 +32,15 @@ func (r *UserRepository) Create(name, email string) (*ent.User, error) {
 		return nil, fmt.Errorf("このメールアドレスは既に登録されています")
 	}
 
+	index, err := r.db.User.Query().Count(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user count: %w", err)
+	}
+
 	user, err := r.db.User.Create().
 		SetName(name).
 		SetEmail(email).
+		SetIndex(index).
 		Save(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create user in database: %w", err)

--- a/backend-go/internal/infra/user.go
+++ b/backend-go/internal/infra/user.go
@@ -32,15 +32,9 @@ func (r *UserRepository) Create(name, email string) (*ent.User, error) {
 		return nil, fmt.Errorf("このメールアドレスは既に登録されています")
 	}
 
-	index, err := r.db.User.Query().Count(context.Background())
-	if err != nil {
-		return nil, fmt.Errorf("failed to get user count: %w", err)
-	}
-
 	user, err := r.db.User.Create().
 		SetName(name).
 		SetEmail(email).
-		SetIndex(index).
 		Save(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create user in database: %w", err)

--- a/backend-go/internal/injector/injector.go
+++ b/backend-go/internal/injector/injector.go
@@ -5,11 +5,11 @@ import (
 	"log"
 	"os"
 
-	"github.com/htanos/animalia/backend-go/ent"
-	"github.com/htanos/animalia/backend-go/internal/domain/repository"
-	"github.com/htanos/animalia/backend-go/internal/handler"
-	"github.com/htanos/animalia/backend-go/internal/infra"
-	"github.com/htanos/animalia/backend-go/internal/usecase"
+	"github.com/aki-13627/animalia/backend-go/ent"
+	"github.com/aki-13627/animalia/backend-go/internal/domain/repository"
+	"github.com/aki-13627/animalia/backend-go/internal/handler"
+	"github.com/aki-13627/animalia/backend-go/internal/infra"
+	"github.com/aki-13627/animalia/backend-go/internal/usecase"
 	_ "github.com/lib/pq" // PostgreSQLドライバー
 )
 

--- a/backend-go/internal/routes/auth_routes.go
+++ b/backend-go/internal/routes/auth_routes.go
@@ -1,8 +1,8 @@
 package routes
 
 import (
+	"github.com/aki-13627/animalia/backend-go/internal/injector"
 	"github.com/gofiber/fiber/v2"
-	"github.com/htanos/animalia/backend-go/internal/injector"
 )
 
 // SetupAuthRoutes sets up the auth routes

--- a/backend-go/internal/routes/pet_routes.go
+++ b/backend-go/internal/routes/pet_routes.go
@@ -1,8 +1,8 @@
 package routes
 
 import (
+	"github.com/aki-13627/animalia/backend-go/internal/injector"
 	"github.com/gofiber/fiber/v2"
-	"github.com/htanos/animalia/backend-go/internal/injector"
 )
 
 // SetupPetRoutes sets up the pet routes

--- a/backend-go/internal/routes/post_routes.go
+++ b/backend-go/internal/routes/post_routes.go
@@ -1,8 +1,8 @@
 package routes
 
 import (
+	"github.com/aki-13627/animalia/backend-go/internal/injector"
 	"github.com/gofiber/fiber/v2"
-	"github.com/htanos/animalia/backend-go/internal/injector"
 )
 
 // SetupPostRoutes sets up the post routes

--- a/backend-go/internal/routes/user_routes.go
+++ b/backend-go/internal/routes/user_routes.go
@@ -1,8 +1,8 @@
 package routes
 
 import (
+	"github.com/aki-13627/animalia/backend-go/internal/injector"
 	"github.com/gofiber/fiber/v2"
-	"github.com/htanos/animalia/backend-go/internal/injector"
 )
 
 func SetupUserRoutes(app *fiber.App) {

--- a/backend-go/internal/seed/seed.go
+++ b/backend-go/internal/seed/seed.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/htanos/animalia/backend-go/ent"
+	"github.com/aki-13627/animalia/backend-go/ent"
 	"github.com/rs/zerolog/log"
 )
 
@@ -13,7 +13,7 @@ func SeedData(client *ent.Client) error {
 
 	log.Info().Msg("Seeding database...")
 
-	clearDatabase(client)
+	ClearDatabase(client)
 
 	// Create users
 	users, err := client.User.CreateBulk(
@@ -80,8 +80,8 @@ func SeedData(client *ent.Client) error {
 	return nil
 }
 
-// clearDatabase clears all data from the database
-func clearDatabase(client *ent.Client) error {
+// ClearDatabase clears all data from the database
+func ClearDatabase(client *ent.Client) error {
 	log.Info().Msg("Clearing database...")
 	ctx := context.Background()
 

--- a/backend-go/internal/usecase/auth.go
+++ b/backend-go/internal/usecase/auth.go
@@ -1,9 +1,9 @@
 package usecase
 
 import (
+	"github.com/aki-13627/animalia/backend-go/ent"
+	"github.com/aki-13627/animalia/backend-go/internal/domain/repository"
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
-	"github.com/htanos/animalia/backend-go/ent"
-	"github.com/htanos/animalia/backend-go/internal/domain/repository"
 )
 
 type AuthUsecase struct {

--- a/backend-go/internal/usecase/pet.go
+++ b/backend-go/internal/usecase/pet.go
@@ -1,8 +1,8 @@
 package usecase
 
 import (
-	"github.com/htanos/animalia/backend-go/ent"
-	"github.com/htanos/animalia/backend-go/internal/domain/repository"
+	"github.com/aki-13627/animalia/backend-go/ent"
+	"github.com/aki-13627/animalia/backend-go/internal/domain/repository"
 )
 
 type PetUsecase struct {

--- a/backend-go/internal/usecase/post.go
+++ b/backend-go/internal/usecase/post.go
@@ -1,8 +1,8 @@
 package usecase
 
 import (
-	"github.com/htanos/animalia/backend-go/ent"
-	"github.com/htanos/animalia/backend-go/internal/domain/repository"
+	"github.com/aki-13627/animalia/backend-go/ent"
+	"github.com/aki-13627/animalia/backend-go/internal/domain/repository"
 )
 
 type PostUsecase struct {

--- a/backend-go/internal/usecase/storage.go
+++ b/backend-go/internal/usecase/storage.go
@@ -3,7 +3,7 @@ package usecase
 import (
 	"mime/multipart"
 
-	"github.com/htanos/animalia/backend-go/internal/domain/repository"
+	"github.com/aki-13627/animalia/backend-go/internal/domain/repository"
 )
 
 type StorageUsecase struct {

--- a/backend-go/internal/usecase/user.go
+++ b/backend-go/internal/usecase/user.go
@@ -1,8 +1,8 @@
 package usecase
 
 import (
-	"github.com/htanos/animalia/backend-go/ent"
-	"github.com/htanos/animalia/backend-go/internal/domain/repository"
+	"github.com/aki-13627/animalia/backend-go/ent"
+	"github.com/aki-13627/animalia/backend-go/internal/domain/repository"
 )
 
 type UserUsecase struct {

--- a/backend-go/tools.go
+++ b/backend-go/tools.go
@@ -6,4 +6,6 @@ package tools
 // 以下のインポートは、go.mod に依存関係を残すためだけに行います。
 import (
 	_ "github.com/olekukonko/tablewriter"
+	_ "github.com/spf13/cobra"
+	_ "github.com/spf13/pflag"
 )


### PR DESCRIPTION
## Summary by Sourcery

Update repository namespace from htanos to aki-13627 across the backend Go project

Enhancements:
- Modify go.mod to reflect the new repository name
- Update import statements in multiple files to use the new repository path

Chores:
- Update all import paths to use the new GitHub repository namespace