### PR TITLE
chore: iconImageKeyをnullableに

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ run: build
 run-attach: build
 	docker compose up api
 
-run-seed:
-	SEED=true docker compose up api -d
+run-seed: build
+	SEED=true docker compose up api
 
 build:
 	docker compose build

--- a/backend-go/ent/migrate/schema.go
+++ b/backend-go/ent/migrate/schema.go
@@ -147,7 +147,7 @@ var (
 		{Name: "email", Type: field.TypeString},
 		{Name: "name", Type: field.TypeString},
 		{Name: "bio", Type: field.TypeString},
-		{Name: "icon_image_key", Type: field.TypeString},
+		{Name: "icon_image_key", Type: field.TypeString, Nullable: true},
 		{Name: "created_at", Type: field.TypeTime},
 	}
 	// UsersTable holds the schema information for the "users" table.

--- a/backend-go/ent/mutation.go
+++ b/backend-go/ent/mutation.go
@@ -3387,9 +3387,22 @@ func (m *UserMutation) OldIconImageKey(ctx context.Context) (v string, err error
 	return oldValue.IconImageKey, nil
 }
 
+// ClearIconImageKey clears the value of the "icon_image_key" field.
+func (m *UserMutation) ClearIconImageKey() {
+	m.icon_image_key = nil
+	m.clearedFields[user.FieldIconImageKey] = struct{}{}
+}
+
+// IconImageKeyCleared returns if the "icon_image_key" field was cleared in this mutation.
+func (m *UserMutation) IconImageKeyCleared() bool {
+	_, ok := m.clearedFields[user.FieldIconImageKey]
+	return ok
+}
+
 // ResetIconImageKey resets all changes to the "icon_image_key" field.
 func (m *UserMutation) ResetIconImageKey() {
 	m.icon_image_key = nil
+	delete(m.clearedFields, user.FieldIconImageKey)
 }
 
 // SetCreatedAt sets the "created_at" field.
@@ -3912,7 +3925,11 @@ func (m *UserMutation) AddField(name string, value ent.Value) error {
 // ClearedFields returns all nullable fields that were cleared during this
 // mutation.
 func (m *UserMutation) ClearedFields() []string {
-	return nil
+	var fields []string
+	if m.FieldCleared(user.FieldIconImageKey) {
+		fields = append(fields, user.FieldIconImageKey)
+	}
+	return fields
 }
 
 // FieldCleared returns a boolean indicating if a field with the given name was
@@ -3925,6 +3942,11 @@ func (m *UserMutation) FieldCleared(name string) bool {
 // ClearField clears the value of the field with the given name. It returns an
 // error if the field is not defined in the schema.
 func (m *UserMutation) ClearField(name string) error {
+	switch name {
+	case user.FieldIconImageKey:
+		m.ClearIconImageKey()
+		return nil
+	}
 	return fmt.Errorf("unknown User nullable field %s", name)
 }
 

--- a/backend-go/ent/schema/user.go
+++ b/backend-go/ent/schema/user.go
@@ -21,7 +21,7 @@ func (User) Fields() []ent.Field {
 		field.String("email").NotEmpty(),
 		field.String("name").NotEmpty(),
 		field.String("bio"),
-		field.String("icon_image_key"),
+		field.String("icon_image_key").Optional(),
 		field.Time("created_at").Default(time.Now),
 	}
 }

--- a/backend-go/ent/user/where.go
+++ b/backend-go/ent/user/where.go
@@ -331,6 +331,16 @@ func IconImageKeyHasSuffix(v string) predicate.User {
 	return predicate.User(sql.FieldHasSuffix(FieldIconImageKey, v))
 }
 
+// IconImageKeyIsNil applies the IsNil predicate on the "icon_image_key" field.
+func IconImageKeyIsNil() predicate.User {
+	return predicate.User(sql.FieldIsNull(FieldIconImageKey))
+}
+
+// IconImageKeyNotNil applies the NotNil predicate on the "icon_image_key" field.
+func IconImageKeyNotNil() predicate.User {
+	return predicate.User(sql.FieldNotNull(FieldIconImageKey))
+}
+
 // IconImageKeyEqualFold applies the EqualFold predicate on the "icon_image_key" field.
 func IconImageKeyEqualFold(v string) predicate.User {
 	return predicate.User(sql.FieldEqualFold(FieldIconImageKey, v))

--- a/backend-go/ent/user_create.go
+++ b/backend-go/ent/user_create.go
@@ -50,6 +50,14 @@ func (uc *UserCreate) SetIconImageKey(s string) *UserCreate {
 	return uc
 }
 
+// SetNillableIconImageKey sets the "icon_image_key" field if the given value is not nil.
+func (uc *UserCreate) SetNillableIconImageKey(s *string) *UserCreate {
+	if s != nil {
+		uc.SetIconImageKey(*s)
+	}
+	return uc
+}
+
 // SetCreatedAt sets the "created_at" field.
 func (uc *UserCreate) SetCreatedAt(t time.Time) *UserCreate {
 	uc.mutation.SetCreatedAt(t)
@@ -233,9 +241,6 @@ func (uc *UserCreate) check() error {
 	}
 	if _, ok := uc.mutation.Bio(); !ok {
 		return &ValidationError{Name: "bio", err: errors.New(`ent: missing required field "User.bio"`)}
-	}
-	if _, ok := uc.mutation.IconImageKey(); !ok {
-		return &ValidationError{Name: "icon_image_key", err: errors.New(`ent: missing required field "User.icon_image_key"`)}
 	}
 	if _, ok := uc.mutation.CreatedAt(); !ok {
 		return &ValidationError{Name: "created_at", err: errors.New(`ent: missing required field "User.created_at"`)}

--- a/backend-go/ent/user_update.go
+++ b/backend-go/ent/user_update.go
@@ -90,6 +90,12 @@ func (uu *UserUpdate) SetNillableIconImageKey(s *string) *UserUpdate {
 	return uu
 }
 
+// ClearIconImageKey clears the value of the "icon_image_key" field.
+func (uu *UserUpdate) ClearIconImageKey() *UserUpdate {
+	uu.mutation.ClearIconImageKey()
+	return uu
+}
+
 // SetCreatedAt sets the "created_at" field.
 func (uu *UserUpdate) SetCreatedAt(t time.Time) *UserUpdate {
 	uu.mutation.SetCreatedAt(t)
@@ -390,6 +396,9 @@ func (uu *UserUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := uu.mutation.IconImageKey(); ok {
 		_spec.SetField(user.FieldIconImageKey, field.TypeString, value)
+	}
+	if uu.mutation.IconImageKeyCleared() {
+		_spec.ClearField(user.FieldIconImageKey, field.TypeString)
 	}
 	if value, ok := uu.mutation.CreatedAt(); ok {
 		_spec.SetField(user.FieldCreatedAt, field.TypeTime, value)
@@ -740,6 +749,12 @@ func (uuo *UserUpdateOne) SetNillableIconImageKey(s *string) *UserUpdateOne {
 	return uuo
 }
 
+// ClearIconImageKey clears the value of the "icon_image_key" field.
+func (uuo *UserUpdateOne) ClearIconImageKey() *UserUpdateOne {
+	uuo.mutation.ClearIconImageKey()
+	return uuo
+}
+
 // SetCreatedAt sets the "created_at" field.
 func (uuo *UserUpdateOne) SetCreatedAt(t time.Time) *UserUpdateOne {
 	uuo.mutation.SetCreatedAt(t)
@@ -1070,6 +1085,9 @@ func (uuo *UserUpdateOne) sqlSave(ctx context.Context) (_node *User, err error) 
 	}
 	if value, ok := uuo.mutation.IconImageKey(); ok {
 		_spec.SetField(user.FieldIconImageKey, field.TypeString, value)
+	}
+	if uuo.mutation.IconImageKeyCleared() {
+		_spec.ClearField(user.FieldIconImageKey, field.TypeString)
 	}
 	if value, ok := uuo.mutation.CreatedAt(); ok {
 		_spec.SetField(user.FieldCreatedAt, field.TypeTime, value)


### PR DESCRIPTION
## Summary by Sourcery

Make the icon_image_key field nullable in the User model, allowing it to be optional and cleared

Enhancements:
- Add methods to clear and check the nullability of icon_image_key
- Remove required validation for icon_image_key

Chores:
- Update schema and mutation methods to support nullable icon_image_key field