### PR TITLE
chore: user bioを空文字で初期化

### DIFF
--- a/backend-go/ent/migrate/schema.go
+++ b/backend-go/ent/migrate/schema.go
@@ -146,7 +146,7 @@ var (
 		{Name: "id", Type: field.TypeUUID, Unique: true},
 		{Name: "email", Type: field.TypeString, Unique: true},
 		{Name: "name", Type: field.TypeString},
-		{Name: "bio", Type: field.TypeString},
+		{Name: "bio", Type: field.TypeString, Default: ""},
 		{Name: "icon_image_key", Type: field.TypeString, Nullable: true},
 		{Name: "created_at", Type: field.TypeTime},
 	}

--- a/backend-go/ent/runtime.go
+++ b/backend-go/ent/runtime.go
@@ -103,6 +103,10 @@ func init() {
 	userDescName := userFields[2].Descriptor()
 	// user.NameValidator is a validator for the "name" field. It is called by the builders before save.
 	user.NameValidator = userDescName.Validators[0].(func(string) error)
+	// userDescBio is the schema descriptor for bio field.
+	userDescBio := userFields[3].Descriptor()
+	// user.DefaultBio holds the default value on creation for the bio field.
+	user.DefaultBio = userDescBio.Default.(string)
 	// userDescCreatedAt is the schema descriptor for created_at field.
 	userDescCreatedAt := userFields[5].Descriptor()
 	// user.DefaultCreatedAt holds the default value on creation for the created_at field.

--- a/backend-go/ent/schema/user.go
+++ b/backend-go/ent/schema/user.go
@@ -20,7 +20,7 @@ func (User) Fields() []ent.Field {
 		field.UUID("id", uuid.UUID{}).Default(uuid.New).Unique(),
 		field.String("email").NotEmpty().Unique(),
 		field.String("name").NotEmpty(),
-		field.String("bio"),
+		field.String("bio").Default(""),
 		field.String("icon_image_key").Optional(),
 		field.Time("created_at").Default(time.Now),
 	}

--- a/backend-go/ent/user/user.go
+++ b/backend-go/ent/user/user.go
@@ -108,6 +108,8 @@ var (
 	EmailValidator func(string) error
 	// NameValidator is a validator for the "name" field. It is called by the builders before save.
 	NameValidator func(string) error
+	// DefaultBio holds the default value on creation for the "bio" field.
+	DefaultBio string
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time
 	// DefaultID holds the default value on creation for the "id" field.

--- a/backend-go/ent/user_create.go
+++ b/backend-go/ent/user_create.go
@@ -44,6 +44,14 @@ func (uc *UserCreate) SetBio(s string) *UserCreate {
 	return uc
 }
 
+// SetNillableBio sets the "bio" field if the given value is not nil.
+func (uc *UserCreate) SetNillableBio(s *string) *UserCreate {
+	if s != nil {
+		uc.SetBio(*s)
+	}
+	return uc
+}
+
 // SetIconImageKey sets the "icon_image_key" field.
 func (uc *UserCreate) SetIconImageKey(s string) *UserCreate {
 	uc.mutation.SetIconImageKey(s)
@@ -211,6 +219,10 @@ func (uc *UserCreate) ExecX(ctx context.Context) {
 
 // defaults sets the default values of the builder before save.
 func (uc *UserCreate) defaults() {
+	if _, ok := uc.mutation.Bio(); !ok {
+		v := user.DefaultBio
+		uc.mutation.SetBio(v)
+	}
 	if _, ok := uc.mutation.CreatedAt(); !ok {
 		v := user.DefaultCreatedAt()
 		uc.mutation.SetCreatedAt(v)


### PR DESCRIPTION
## Summary by Sourcery

Initialize user bio with an empty string as the default value

Enhancements:
- Introduce a new SetNillableBio method for optional bio setting
- Update user creation logic to ensure bio has a default empty string

Chores:
- Add default empty string for user bio field across the user schema and related generated code