### PR TITLE
chore: PetResponseからownerを削除

### DIFF
--- a/backend-go/ent/comment_create.go
+++ b/backend-go/ent/comment_create.go
@@ -66,14 +66,6 @@ func (cc *CommentCreate) SetPostID(id uuid.UUID) *CommentCreate {
 	return cc
 }
 
-// SetNillablePostID sets the "post" edge to the Post entity by ID if the given value is not nil.
-func (cc *CommentCreate) SetNillablePostID(id *uuid.UUID) *CommentCreate {
-	if id != nil {
-		cc = cc.SetPostID(*id)
-	}
-	return cc
-}
-
 // SetPost sets the "post" edge to the Post entity.
 func (cc *CommentCreate) SetPost(p *Post) *CommentCreate {
 	return cc.SetPostID(p.ID)
@@ -82,14 +74,6 @@ func (cc *CommentCreate) SetPost(p *Post) *CommentCreate {
 // SetUserID sets the "user" edge to the User entity by ID.
 func (cc *CommentCreate) SetUserID(id uuid.UUID) *CommentCreate {
 	cc.mutation.SetUserID(id)
-	return cc
-}
-
-// SetNillableUserID sets the "user" edge to the User entity by ID if the given value is not nil.
-func (cc *CommentCreate) SetNillableUserID(id *uuid.UUID) *CommentCreate {
-	if id != nil {
-		cc = cc.SetUserID(*id)
-	}
 	return cc
 }
 
@@ -155,6 +139,12 @@ func (cc *CommentCreate) check() error {
 	}
 	if _, ok := cc.mutation.CreatedAt(); !ok {
 		return &ValidationError{Name: "created_at", err: errors.New(`ent: missing required field "Comment.created_at"`)}
+	}
+	if len(cc.mutation.PostIDs()) == 0 {
+		return &ValidationError{Name: "post", err: errors.New(`ent: missing required edge "Comment.post"`)}
+	}
+	if len(cc.mutation.UserIDs()) == 0 {
+		return &ValidationError{Name: "user", err: errors.New(`ent: missing required edge "Comment.user"`)}
 	}
 	return nil
 }

--- a/backend-go/ent/comment_update.go
+++ b/backend-go/ent/comment_update.go
@@ -65,14 +65,6 @@ func (cu *CommentUpdate) SetPostID(id uuid.UUID) *CommentUpdate {
 	return cu
 }
 
-// SetNillablePostID sets the "post" edge to the Post entity by ID if the given value is not nil.
-func (cu *CommentUpdate) SetNillablePostID(id *uuid.UUID) *CommentUpdate {
-	if id != nil {
-		cu = cu.SetPostID(*id)
-	}
-	return cu
-}
-
 // SetPost sets the "post" edge to the Post entity.
 func (cu *CommentUpdate) SetPost(p *Post) *CommentUpdate {
 	return cu.SetPostID(p.ID)
@@ -81,14 +73,6 @@ func (cu *CommentUpdate) SetPost(p *Post) *CommentUpdate {
 // SetUserID sets the "user" edge to the User entity by ID.
 func (cu *CommentUpdate) SetUserID(id uuid.UUID) *CommentUpdate {
 	cu.mutation.SetUserID(id)
-	return cu
-}
-
-// SetNillableUserID sets the "user" edge to the User entity by ID if the given value is not nil.
-func (cu *CommentUpdate) SetNillableUserID(id *uuid.UUID) *CommentUpdate {
-	if id != nil {
-		cu = cu.SetUserID(*id)
-	}
 	return cu
 }
 
@@ -147,6 +131,12 @@ func (cu *CommentUpdate) check() error {
 		if err := comment.ContentValidator(v); err != nil {
 			return &ValidationError{Name: "content", err: fmt.Errorf(`ent: validator failed for field "Comment.content": %w`, err)}
 		}
+	}
+	if cu.mutation.PostCleared() && len(cu.mutation.PostIDs()) > 0 {
+		return errors.New(`ent: clearing a required unique edge "Comment.post"`)
+	}
+	if cu.mutation.UserCleared() && len(cu.mutation.UserIDs()) > 0 {
+		return errors.New(`ent: clearing a required unique edge "Comment.user"`)
 	}
 	return nil
 }
@@ -281,14 +271,6 @@ func (cuo *CommentUpdateOne) SetPostID(id uuid.UUID) *CommentUpdateOne {
 	return cuo
 }
 
-// SetNillablePostID sets the "post" edge to the Post entity by ID if the given value is not nil.
-func (cuo *CommentUpdateOne) SetNillablePostID(id *uuid.UUID) *CommentUpdateOne {
-	if id != nil {
-		cuo = cuo.SetPostID(*id)
-	}
-	return cuo
-}
-
 // SetPost sets the "post" edge to the Post entity.
 func (cuo *CommentUpdateOne) SetPost(p *Post) *CommentUpdateOne {
 	return cuo.SetPostID(p.ID)
@@ -297,14 +279,6 @@ func (cuo *CommentUpdateOne) SetPost(p *Post) *CommentUpdateOne {
 // SetUserID sets the "user" edge to the User entity by ID.
 func (cuo *CommentUpdateOne) SetUserID(id uuid.UUID) *CommentUpdateOne {
 	cuo.mutation.SetUserID(id)
-	return cuo
-}
-
-// SetNillableUserID sets the "user" edge to the User entity by ID if the given value is not nil.
-func (cuo *CommentUpdateOne) SetNillableUserID(id *uuid.UUID) *CommentUpdateOne {
-	if id != nil {
-		cuo = cuo.SetUserID(*id)
-	}
 	return cuo
 }
 
@@ -376,6 +350,12 @@ func (cuo *CommentUpdateOne) check() error {
 		if err := comment.ContentValidator(v); err != nil {
 			return &ValidationError{Name: "content", err: fmt.Errorf(`ent: validator failed for field "Comment.content": %w`, err)}
 		}
+	}
+	if cuo.mutation.PostCleared() && len(cuo.mutation.PostIDs()) > 0 {
+		return errors.New(`ent: clearing a required unique edge "Comment.post"`)
+	}
+	if cuo.mutation.UserCleared() && len(cuo.mutation.UserIDs()) > 0 {
+		return errors.New(`ent: clearing a required unique edge "Comment.user"`)
 	}
 	return nil
 }

--- a/backend-go/ent/followrelation_create.go
+++ b/backend-go/ent/followrelation_create.go
@@ -59,14 +59,6 @@ func (frc *FollowRelationCreate) SetFromID(id uuid.UUID) *FollowRelationCreate {
 	return frc
 }
 
-// SetNillableFromID sets the "from" edge to the User entity by ID if the given value is not nil.
-func (frc *FollowRelationCreate) SetNillableFromID(id *uuid.UUID) *FollowRelationCreate {
-	if id != nil {
-		frc = frc.SetFromID(*id)
-	}
-	return frc
-}
-
 // SetFrom sets the "from" edge to the User entity.
 func (frc *FollowRelationCreate) SetFrom(u *User) *FollowRelationCreate {
 	return frc.SetFromID(u.ID)
@@ -75,14 +67,6 @@ func (frc *FollowRelationCreate) SetFrom(u *User) *FollowRelationCreate {
 // SetToID sets the "to" edge to the User entity by ID.
 func (frc *FollowRelationCreate) SetToID(id uuid.UUID) *FollowRelationCreate {
 	frc.mutation.SetToID(id)
-	return frc
-}
-
-// SetNillableToID sets the "to" edge to the User entity by ID if the given value is not nil.
-func (frc *FollowRelationCreate) SetNillableToID(id *uuid.UUID) *FollowRelationCreate {
-	if id != nil {
-		frc = frc.SetToID(*id)
-	}
 	return frc
 }
 
@@ -140,6 +124,12 @@ func (frc *FollowRelationCreate) defaults() {
 func (frc *FollowRelationCreate) check() error {
 	if _, ok := frc.mutation.CreatedAt(); !ok {
 		return &ValidationError{Name: "created_at", err: errors.New(`ent: missing required field "FollowRelation.created_at"`)}
+	}
+	if len(frc.mutation.FromIDs()) == 0 {
+		return &ValidationError{Name: "from", err: errors.New(`ent: missing required edge "FollowRelation.from"`)}
+	}
+	if len(frc.mutation.ToIDs()) == 0 {
+		return &ValidationError{Name: "to", err: errors.New(`ent: missing required edge "FollowRelation.to"`)}
 	}
 	return nil
 }

--- a/backend-go/ent/followrelation_update.go
+++ b/backend-go/ent/followrelation_update.go
@@ -50,14 +50,6 @@ func (fru *FollowRelationUpdate) SetFromID(id uuid.UUID) *FollowRelationUpdate {
 	return fru
 }
 
-// SetNillableFromID sets the "from" edge to the User entity by ID if the given value is not nil.
-func (fru *FollowRelationUpdate) SetNillableFromID(id *uuid.UUID) *FollowRelationUpdate {
-	if id != nil {
-		fru = fru.SetFromID(*id)
-	}
-	return fru
-}
-
 // SetFrom sets the "from" edge to the User entity.
 func (fru *FollowRelationUpdate) SetFrom(u *User) *FollowRelationUpdate {
 	return fru.SetFromID(u.ID)
@@ -66,14 +58,6 @@ func (fru *FollowRelationUpdate) SetFrom(u *User) *FollowRelationUpdate {
 // SetToID sets the "to" edge to the User entity by ID.
 func (fru *FollowRelationUpdate) SetToID(id uuid.UUID) *FollowRelationUpdate {
 	fru.mutation.SetToID(id)
-	return fru
-}
-
-// SetNillableToID sets the "to" edge to the User entity by ID if the given value is not nil.
-func (fru *FollowRelationUpdate) SetNillableToID(id *uuid.UUID) *FollowRelationUpdate {
-	if id != nil {
-		fru = fru.SetToID(*id)
-	}
 	return fru
 }
 
@@ -126,7 +110,21 @@ func (fru *FollowRelationUpdate) ExecX(ctx context.Context) {
 	}
 }
 
+// check runs all checks and user-defined validators on the builder.
+func (fru *FollowRelationUpdate) check() error {
+	if fru.mutation.FromCleared() && len(fru.mutation.FromIDs()) > 0 {
+		return errors.New(`ent: clearing a required unique edge "FollowRelation.from"`)
+	}
+	if fru.mutation.ToCleared() && len(fru.mutation.ToIDs()) > 0 {
+		return errors.New(`ent: clearing a required unique edge "FollowRelation.to"`)
+	}
+	return nil
+}
+
 func (fru *FollowRelationUpdate) sqlSave(ctx context.Context) (n int, err error) {
+	if err := fru.check(); err != nil {
+		return n, err
+	}
 	_spec := sqlgraph.NewUpdateSpec(followrelation.Table, followrelation.Columns, sqlgraph.NewFieldSpec(followrelation.FieldID, field.TypeUUID))
 	if ps := fru.mutation.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
@@ -236,14 +234,6 @@ func (fruo *FollowRelationUpdateOne) SetFromID(id uuid.UUID) *FollowRelationUpda
 	return fruo
 }
 
-// SetNillableFromID sets the "from" edge to the User entity by ID if the given value is not nil.
-func (fruo *FollowRelationUpdateOne) SetNillableFromID(id *uuid.UUID) *FollowRelationUpdateOne {
-	if id != nil {
-		fruo = fruo.SetFromID(*id)
-	}
-	return fruo
-}
-
 // SetFrom sets the "from" edge to the User entity.
 func (fruo *FollowRelationUpdateOne) SetFrom(u *User) *FollowRelationUpdateOne {
 	return fruo.SetFromID(u.ID)
@@ -252,14 +242,6 @@ func (fruo *FollowRelationUpdateOne) SetFrom(u *User) *FollowRelationUpdateOne {
 // SetToID sets the "to" edge to the User entity by ID.
 func (fruo *FollowRelationUpdateOne) SetToID(id uuid.UUID) *FollowRelationUpdateOne {
 	fruo.mutation.SetToID(id)
-	return fruo
-}
-
-// SetNillableToID sets the "to" edge to the User entity by ID if the given value is not nil.
-func (fruo *FollowRelationUpdateOne) SetNillableToID(id *uuid.UUID) *FollowRelationUpdateOne {
-	if id != nil {
-		fruo = fruo.SetToID(*id)
-	}
 	return fruo
 }
 
@@ -325,7 +307,21 @@ func (fruo *FollowRelationUpdateOne) ExecX(ctx context.Context) {
 	}
 }
 
+// check runs all checks and user-defined validators on the builder.
+func (fruo *FollowRelationUpdateOne) check() error {
+	if fruo.mutation.FromCleared() && len(fruo.mutation.FromIDs()) > 0 {
+		return errors.New(`ent: clearing a required unique edge "FollowRelation.from"`)
+	}
+	if fruo.mutation.ToCleared() && len(fruo.mutation.ToIDs()) > 0 {
+		return errors.New(`ent: clearing a required unique edge "FollowRelation.to"`)
+	}
+	return nil
+}
+
 func (fruo *FollowRelationUpdateOne) sqlSave(ctx context.Context) (_node *FollowRelation, err error) {
+	if err := fruo.check(); err != nil {
+		return _node, err
+	}
 	_spec := sqlgraph.NewUpdateSpec(followrelation.Table, followrelation.Columns, sqlgraph.NewFieldSpec(followrelation.FieldID, field.TypeUUID))
 	id, ok := fruo.mutation.ID()
 	if !ok {

--- a/backend-go/ent/like_create.go
+++ b/backend-go/ent/like_create.go
@@ -60,14 +60,6 @@ func (lc *LikeCreate) SetUserID(id uuid.UUID) *LikeCreate {
 	return lc
 }
 
-// SetNillableUserID sets the "user" edge to the User entity by ID if the given value is not nil.
-func (lc *LikeCreate) SetNillableUserID(id *uuid.UUID) *LikeCreate {
-	if id != nil {
-		lc = lc.SetUserID(*id)
-	}
-	return lc
-}
-
 // SetUser sets the "user" edge to the User entity.
 func (lc *LikeCreate) SetUser(u *User) *LikeCreate {
 	return lc.SetUserID(u.ID)
@@ -76,14 +68,6 @@ func (lc *LikeCreate) SetUser(u *User) *LikeCreate {
 // SetPostID sets the "post" edge to the Post entity by ID.
 func (lc *LikeCreate) SetPostID(id uuid.UUID) *LikeCreate {
 	lc.mutation.SetPostID(id)
-	return lc
-}
-
-// SetNillablePostID sets the "post" edge to the Post entity by ID if the given value is not nil.
-func (lc *LikeCreate) SetNillablePostID(id *uuid.UUID) *LikeCreate {
-	if id != nil {
-		lc = lc.SetPostID(*id)
-	}
 	return lc
 }
 
@@ -141,6 +125,12 @@ func (lc *LikeCreate) defaults() {
 func (lc *LikeCreate) check() error {
 	if _, ok := lc.mutation.CreatedAt(); !ok {
 		return &ValidationError{Name: "created_at", err: errors.New(`ent: missing required field "Like.created_at"`)}
+	}
+	if len(lc.mutation.UserIDs()) == 0 {
+		return &ValidationError{Name: "user", err: errors.New(`ent: missing required edge "Like.user"`)}
+	}
+	if len(lc.mutation.PostIDs()) == 0 {
+		return &ValidationError{Name: "post", err: errors.New(`ent: missing required edge "Like.post"`)}
 	}
 	return nil
 }

--- a/backend-go/ent/like_update.go
+++ b/backend-go/ent/like_update.go
@@ -51,14 +51,6 @@ func (lu *LikeUpdate) SetUserID(id uuid.UUID) *LikeUpdate {
 	return lu
 }
 
-// SetNillableUserID sets the "user" edge to the User entity by ID if the given value is not nil.
-func (lu *LikeUpdate) SetNillableUserID(id *uuid.UUID) *LikeUpdate {
-	if id != nil {
-		lu = lu.SetUserID(*id)
-	}
-	return lu
-}
-
 // SetUser sets the "user" edge to the User entity.
 func (lu *LikeUpdate) SetUser(u *User) *LikeUpdate {
 	return lu.SetUserID(u.ID)
@@ -67,14 +59,6 @@ func (lu *LikeUpdate) SetUser(u *User) *LikeUpdate {
 // SetPostID sets the "post" edge to the Post entity by ID.
 func (lu *LikeUpdate) SetPostID(id uuid.UUID) *LikeUpdate {
 	lu.mutation.SetPostID(id)
-	return lu
-}
-
-// SetNillablePostID sets the "post" edge to the Post entity by ID if the given value is not nil.
-func (lu *LikeUpdate) SetNillablePostID(id *uuid.UUID) *LikeUpdate {
-	if id != nil {
-		lu = lu.SetPostID(*id)
-	}
 	return lu
 }
 
@@ -127,7 +111,21 @@ func (lu *LikeUpdate) ExecX(ctx context.Context) {
 	}
 }
 
+// check runs all checks and user-defined validators on the builder.
+func (lu *LikeUpdate) check() error {
+	if lu.mutation.UserCleared() && len(lu.mutation.UserIDs()) > 0 {
+		return errors.New(`ent: clearing a required unique edge "Like.user"`)
+	}
+	if lu.mutation.PostCleared() && len(lu.mutation.PostIDs()) > 0 {
+		return errors.New(`ent: clearing a required unique edge "Like.post"`)
+	}
+	return nil
+}
+
 func (lu *LikeUpdate) sqlSave(ctx context.Context) (n int, err error) {
+	if err := lu.check(); err != nil {
+		return n, err
+	}
 	_spec := sqlgraph.NewUpdateSpec(like.Table, like.Columns, sqlgraph.NewFieldSpec(like.FieldID, field.TypeUUID))
 	if ps := lu.mutation.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
@@ -237,14 +235,6 @@ func (luo *LikeUpdateOne) SetUserID(id uuid.UUID) *LikeUpdateOne {
 	return luo
 }
 
-// SetNillableUserID sets the "user" edge to the User entity by ID if the given value is not nil.
-func (luo *LikeUpdateOne) SetNillableUserID(id *uuid.UUID) *LikeUpdateOne {
-	if id != nil {
-		luo = luo.SetUserID(*id)
-	}
-	return luo
-}
-
 // SetUser sets the "user" edge to the User entity.
 func (luo *LikeUpdateOne) SetUser(u *User) *LikeUpdateOne {
 	return luo.SetUserID(u.ID)
@@ -253,14 +243,6 @@ func (luo *LikeUpdateOne) SetUser(u *User) *LikeUpdateOne {
 // SetPostID sets the "post" edge to the Post entity by ID.
 func (luo *LikeUpdateOne) SetPostID(id uuid.UUID) *LikeUpdateOne {
 	luo.mutation.SetPostID(id)
-	return luo
-}
-
-// SetNillablePostID sets the "post" edge to the Post entity by ID if the given value is not nil.
-func (luo *LikeUpdateOne) SetNillablePostID(id *uuid.UUID) *LikeUpdateOne {
-	if id != nil {
-		luo = luo.SetPostID(*id)
-	}
 	return luo
 }
 
@@ -326,7 +308,21 @@ func (luo *LikeUpdateOne) ExecX(ctx context.Context) {
 	}
 }
 
+// check runs all checks and user-defined validators on the builder.
+func (luo *LikeUpdateOne) check() error {
+	if luo.mutation.UserCleared() && len(luo.mutation.UserIDs()) > 0 {
+		return errors.New(`ent: clearing a required unique edge "Like.user"`)
+	}
+	if luo.mutation.PostCleared() && len(luo.mutation.PostIDs()) > 0 {
+		return errors.New(`ent: clearing a required unique edge "Like.post"`)
+	}
+	return nil
+}
+
 func (luo *LikeUpdateOne) sqlSave(ctx context.Context) (_node *Like, err error) {
+	if err := luo.check(); err != nil {
+		return _node, err
+	}
 	_spec := sqlgraph.NewUpdateSpec(like.Table, like.Columns, sqlgraph.NewFieldSpec(like.FieldID, field.TypeUUID))
 	id, ok := luo.mutation.ID()
 	if !ok {

--- a/backend-go/ent/migrate/schema.go
+++ b/backend-go/ent/migrate/schema.go
@@ -13,8 +13,8 @@ var (
 		{Name: "id", Type: field.TypeUUID, Unique: true},
 		{Name: "content", Type: field.TypeString},
 		{Name: "created_at", Type: field.TypeTime},
-		{Name: "post_comments", Type: field.TypeUUID, Nullable: true},
-		{Name: "user_comments", Type: field.TypeUUID, Nullable: true},
+		{Name: "post_comments", Type: field.TypeUUID},
+		{Name: "user_comments", Type: field.TypeUUID},
 	}
 	// CommentsTable holds the schema information for the "comments" table.
 	CommentsTable = &schema.Table{
@@ -26,13 +26,13 @@ var (
 				Symbol:     "comments_posts_comments",
 				Columns:    []*schema.Column{CommentsColumns[3]},
 				RefColumns: []*schema.Column{PostsColumns[0]},
-				OnDelete:   schema.SetNull,
+				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "comments_users_comments",
 				Columns:    []*schema.Column{CommentsColumns[4]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
-				OnDelete:   schema.SetNull,
+				OnDelete:   schema.NoAction,
 			},
 		},
 	}
@@ -40,8 +40,8 @@ var (
 	FollowRelationsColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeUUID, Unique: true},
 		{Name: "created_at", Type: field.TypeTime},
-		{Name: "user_following", Type: field.TypeUUID, Nullable: true},
-		{Name: "user_followers", Type: field.TypeUUID, Nullable: true},
+		{Name: "user_following", Type: field.TypeUUID},
+		{Name: "user_followers", Type: field.TypeUUID},
 	}
 	// FollowRelationsTable holds the schema information for the "follow_relations" table.
 	FollowRelationsTable = &schema.Table{
@@ -53,13 +53,13 @@ var (
 				Symbol:     "follow_relations_users_following",
 				Columns:    []*schema.Column{FollowRelationsColumns[2]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
-				OnDelete:   schema.SetNull,
+				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "follow_relations_users_followers",
 				Columns:    []*schema.Column{FollowRelationsColumns[3]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
-				OnDelete:   schema.SetNull,
+				OnDelete:   schema.NoAction,
 			},
 		},
 	}
@@ -67,8 +67,8 @@ var (
 	LikesColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeUUID, Unique: true},
 		{Name: "created_at", Type: field.TypeTime},
-		{Name: "post_likes", Type: field.TypeUUID, Nullable: true},
-		{Name: "user_likes", Type: field.TypeUUID, Nullable: true},
+		{Name: "post_likes", Type: field.TypeUUID},
+		{Name: "user_likes", Type: field.TypeUUID},
 	}
 	// LikesTable holds the schema information for the "likes" table.
 	LikesTable = &schema.Table{
@@ -80,13 +80,13 @@ var (
 				Symbol:     "likes_posts_likes",
 				Columns:    []*schema.Column{LikesColumns[2]},
 				RefColumns: []*schema.Column{PostsColumns[0]},
-				OnDelete:   schema.SetNull,
+				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "likes_users_likes",
 				Columns:    []*schema.Column{LikesColumns[3]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
-				OnDelete:   schema.SetNull,
+				OnDelete:   schema.NoAction,
 			},
 		},
 	}
@@ -100,7 +100,7 @@ var (
 		{Name: "image_key", Type: field.TypeString},
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "deleted_at", Type: field.TypeTime, Nullable: true},
-		{Name: "user_pets", Type: field.TypeUUID, Nullable: true},
+		{Name: "user_pets", Type: field.TypeUUID},
 	}
 	// PetsTable holds the schema information for the "pets" table.
 	PetsTable = &schema.Table{
@@ -112,7 +112,7 @@ var (
 				Symbol:     "pets_users_pets",
 				Columns:    []*schema.Column{PetsColumns[8]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
-				OnDelete:   schema.SetNull,
+				OnDelete:   schema.NoAction,
 			},
 		},
 	}
@@ -125,7 +125,7 @@ var (
 		{Name: "deleted_at", Type: field.TypeTime, Nullable: true},
 		{Name: "text_feature", Type: field.TypeOther, Nullable: true, SchemaType: map[string]string{"postgres": "vector(768)"}},
 		{Name: "image_feature", Type: field.TypeOther, Nullable: true, SchemaType: map[string]string{"postgres": "vector(768)"}},
-		{Name: "user_posts", Type: field.TypeUUID, Nullable: true},
+		{Name: "user_posts", Type: field.TypeUUID},
 	}
 	// PostsTable holds the schema information for the "posts" table.
 	PostsTable = &schema.Table{
@@ -137,7 +137,7 @@ var (
 				Symbol:     "posts_users_posts",
 				Columns:    []*schema.Column{PostsColumns[7]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
-				OnDelete:   schema.SetNull,
+				OnDelete:   schema.NoAction,
 			},
 		},
 	}

--- a/backend-go/ent/pet_create.go
+++ b/backend-go/ent/pet_create.go
@@ -103,14 +103,6 @@ func (pc *PetCreate) SetOwnerID(id uuid.UUID) *PetCreate {
 	return pc
 }
 
-// SetNillableOwnerID sets the "owner" edge to the User entity by ID if the given value is not nil.
-func (pc *PetCreate) SetNillableOwnerID(id *uuid.UUID) *PetCreate {
-	if id != nil {
-		pc = pc.SetOwnerID(*id)
-	}
-	return pc
-}
-
 // SetOwner sets the "owner" edge to the User entity.
 func (pc *PetCreate) SetOwner(u *User) *PetCreate {
 	return pc.SetOwnerID(u.ID)
@@ -205,6 +197,9 @@ func (pc *PetCreate) check() error {
 	}
 	if _, ok := pc.mutation.CreatedAt(); !ok {
 		return &ValidationError{Name: "created_at", err: errors.New(`ent: missing required field "Pet.created_at"`)}
+	}
+	if len(pc.mutation.OwnerIDs()) == 0 {
+		return &ValidationError{Name: "owner", err: errors.New(`ent: missing required edge "Pet.owner"`)}
 	}
 	return nil
 }

--- a/backend-go/ent/pet_update.go
+++ b/backend-go/ent/pet_update.go
@@ -140,14 +140,6 @@ func (pu *PetUpdate) SetOwnerID(id uuid.UUID) *PetUpdate {
 	return pu
 }
 
-// SetNillableOwnerID sets the "owner" edge to the User entity by ID if the given value is not nil.
-func (pu *PetUpdate) SetNillableOwnerID(id *uuid.UUID) *PetUpdate {
-	if id != nil {
-		pu = pu.SetOwnerID(*id)
-	}
-	return pu
-}
-
 // SetOwner sets the "owner" edge to the User entity.
 func (pu *PetUpdate) SetOwner(u *User) *PetUpdate {
 	return pu.SetOwnerID(u.ID)
@@ -217,6 +209,9 @@ func (pu *PetUpdate) check() error {
 		if err := pet.ImageKeyValidator(v); err != nil {
 			return &ValidationError{Name: "image_key", err: fmt.Errorf(`ent: validator failed for field "Pet.image_key": %w`, err)}
 		}
+	}
+	if pu.mutation.OwnerCleared() && len(pu.mutation.OwnerIDs()) > 0 {
+		return errors.New(`ent: clearing a required unique edge "Pet.owner"`)
 	}
 	return nil
 }
@@ -416,14 +411,6 @@ func (puo *PetUpdateOne) SetOwnerID(id uuid.UUID) *PetUpdateOne {
 	return puo
 }
 
-// SetNillableOwnerID sets the "owner" edge to the User entity by ID if the given value is not nil.
-func (puo *PetUpdateOne) SetNillableOwnerID(id *uuid.UUID) *PetUpdateOne {
-	if id != nil {
-		puo = puo.SetOwnerID(*id)
-	}
-	return puo
-}
-
 // SetOwner sets the "owner" edge to the User entity.
 func (puo *PetUpdateOne) SetOwner(u *User) *PetUpdateOne {
 	return puo.SetOwnerID(u.ID)
@@ -506,6 +493,9 @@ func (puo *PetUpdateOne) check() error {
 		if err := pet.ImageKeyValidator(v); err != nil {
 			return &ValidationError{Name: "image_key", err: fmt.Errorf(`ent: validator failed for field "Pet.image_key": %w`, err)}
 		}
+	}
+	if puo.mutation.OwnerCleared() && len(puo.mutation.OwnerIDs()) > 0 {
+		return errors.New(`ent: clearing a required unique edge "Pet.owner"`)
 	}
 	return nil
 }

--- a/backend-go/ent/post_create.go
+++ b/backend-go/ent/post_create.go
@@ -116,14 +116,6 @@ func (pc *PostCreate) SetUserID(id uuid.UUID) *PostCreate {
 	return pc
 }
 
-// SetNillableUserID sets the "user" edge to the User entity by ID if the given value is not nil.
-func (pc *PostCreate) SetNillableUserID(id *uuid.UUID) *PostCreate {
-	if id != nil {
-		pc = pc.SetUserID(*id)
-	}
-	return pc
-}
-
 // SetUser sets the "user" edge to the User entity.
 func (pc *PostCreate) SetUser(u *User) *PostCreate {
 	return pc.SetUserID(u.ID)
@@ -224,6 +216,9 @@ func (pc *PostCreate) check() error {
 	}
 	if _, ok := pc.mutation.CreatedAt(); !ok {
 		return &ValidationError{Name: "created_at", err: errors.New(`ent: missing required field "Post.created_at"`)}
+	}
+	if len(pc.mutation.UserIDs()) == 0 {
+		return &ValidationError{Name: "user", err: errors.New(`ent: missing required edge "Post.user"`)}
 	}
 	return nil
 }

--- a/backend-go/ent/post_update.go
+++ b/backend-go/ent/post_update.go
@@ -141,14 +141,6 @@ func (pu *PostUpdate) SetUserID(id uuid.UUID) *PostUpdate {
 	return pu
 }
 
-// SetNillableUserID sets the "user" edge to the User entity by ID if the given value is not nil.
-func (pu *PostUpdate) SetNillableUserID(id *uuid.UUID) *PostUpdate {
-	if id != nil {
-		pu = pu.SetUserID(*id)
-	}
-	return pu
-}
-
 // SetUser sets the "user" edge to the User entity.
 func (pu *PostUpdate) SetUser(u *User) *PostUpdate {
 	return pu.SetUserID(u.ID)
@@ -275,6 +267,9 @@ func (pu *PostUpdate) check() error {
 		if err := post.ImageKeyValidator(v); err != nil {
 			return &ValidationError{Name: "image_key", err: fmt.Errorf(`ent: validator failed for field "Post.image_key": %w`, err)}
 		}
+	}
+	if pu.mutation.UserCleared() && len(pu.mutation.UserIDs()) > 0 {
+		return errors.New(`ent: clearing a required unique edge "Post.user"`)
 	}
 	return nil
 }
@@ -565,14 +560,6 @@ func (puo *PostUpdateOne) SetUserID(id uuid.UUID) *PostUpdateOne {
 	return puo
 }
 
-// SetNillableUserID sets the "user" edge to the User entity by ID if the given value is not nil.
-func (puo *PostUpdateOne) SetNillableUserID(id *uuid.UUID) *PostUpdateOne {
-	if id != nil {
-		puo = puo.SetUserID(*id)
-	}
-	return puo
-}
-
 // SetUser sets the "user" edge to the User entity.
 func (puo *PostUpdateOne) SetUser(u *User) *PostUpdateOne {
 	return puo.SetUserID(u.ID)
@@ -712,6 +699,9 @@ func (puo *PostUpdateOne) check() error {
 		if err := post.ImageKeyValidator(v); err != nil {
 			return &ValidationError{Name: "image_key", err: fmt.Errorf(`ent: validator failed for field "Post.image_key": %w`, err)}
 		}
+	}
+	if puo.mutation.UserCleared() && len(puo.mutation.UserIDs()) > 0 {
+		return errors.New(`ent: clearing a required unique edge "Post.user"`)
 	}
 	return nil
 }

--- a/backend-go/ent/schema/comment.go
+++ b/backend-go/ent/schema/comment.go
@@ -26,7 +26,7 @@ func (Comment) Fields() []ent.Field {
 // Edges of the Comment.
 func (Comment) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.From("post", Post.Type).Ref("comments").Unique(),
-		edge.From("user", User.Type).Ref("comments").Unique(),
+		edge.From("post", Post.Type).Ref("comments").Unique().Required(),
+		edge.From("user", User.Type).Ref("comments").Unique().Required(),
 	}
 }

--- a/backend-go/ent/schema/followrelation.go
+++ b/backend-go/ent/schema/followrelation.go
@@ -25,7 +25,7 @@ func (FollowRelation) Fields() []ent.Field {
 // Edges of the FollowRelation.
 func (FollowRelation) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.From("from", User.Type).Ref("following").Unique(),
-		edge.From("to", User.Type).Ref("followers").Unique(),
+		edge.From("from", User.Type).Ref("following").Unique().Required(),
+		edge.From("to", User.Type).Ref("followers").Unique().Required(),
 	}
 }

--- a/backend-go/ent/schema/like.go
+++ b/backend-go/ent/schema/like.go
@@ -25,7 +25,7 @@ func (Like) Fields() []ent.Field {
 // Edges of the Like.
 func (Like) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.From("user", User.Type).Ref("likes").Unique(),
-		edge.From("post", Post.Type).Ref("likes").Unique(),
+		edge.From("user", User.Type).Ref("likes").Unique().Required(),
+		edge.From("post", Post.Type).Ref("likes").Unique().Required(),
 	}
 }

--- a/backend-go/ent/schema/pet.go
+++ b/backend-go/ent/schema/pet.go
@@ -52,6 +52,6 @@ func (Pet) Fields() []ent.Field {
 // Edges of the Pet.
 func (Pet) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.From("owner", User.Type).Ref("pets").Unique(),
+		edge.From("owner", User.Type).Ref("pets").Unique().Required(),
 	}
 }

--- a/backend-go/ent/schema/post.go
+++ b/backend-go/ent/schema/post.go
@@ -38,7 +38,7 @@ func (Post) Fields() []ent.Field {
 // Edges of the Post.
 func (Post) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.From("user", User.Type).Ref("posts").Unique(),
+		edge.From("user", User.Type).Ref("posts").Unique().Required(),
 		edge.To("comments", Comment.Type),
 		edge.To("likes", Like.Type),
 	}

--- a/backend-go/internal/domain/models/pet.go
+++ b/backend-go/internal/domain/models/pet.go
@@ -23,7 +23,7 @@ type PetResponse struct {
 
 // NewPetResponse converts a Pet to a PetResponse
 func NewPetResponse(pet *ent.Pet, imageURL string) PetResponse {
-	owner, _ := pet.Edges.OwnerOrErr()
+	owner := pet.Edges.Owner
 	return PetResponse{
 		ID:        pet.ID,
 		Name:      pet.Name,

--- a/backend-go/internal/domain/models/pet.go
+++ b/backend-go/internal/domain/models/pet.go
@@ -23,7 +23,6 @@ type PetResponse struct {
 
 // NewPetResponse converts a Pet to a PetResponse
 func NewPetResponse(pet *ent.Pet, imageURL string) PetResponse {
-	owner := pet.Edges.Owner
 	return PetResponse{
 		ID:        pet.ID,
 		Name:      pet.Name,
@@ -31,8 +30,6 @@ func NewPetResponse(pet *ent.Pet, imageURL string) PetResponse {
 		Type:      pet.Type,
 		Species:   pet.Species,
 		ImageURL:  imageURL,
-		OwnerID:   owner.ID,
-		Owner:     owner,
 		CreatedAt: pet.CreatedAt,
 	}
 }

--- a/backend-go/internal/domain/models/post.go
+++ b/backend-go/internal/domain/models/post.go
@@ -10,7 +10,8 @@ import (
 type PostResponse struct {
 	ID        uuid.UUID `json:"id"`
 	Caption   string    `json:"caption"`
-	ImageURL  string    `json:"imageURL"`
+	UserId    uuid.UUID `json:"userId"`
+	ImageURL  string    `json:"imageUrl"`
 	CreatedAt time.Time `json:"createdAt"`
 }
 
@@ -18,6 +19,7 @@ func NewPostResponse(post *ent.Post, imageURL string) *PostResponse {
 	return &PostResponse{
 		ID:        post.ID,
 		Caption:   post.Caption,
+		UserId:    post.Edges.User.ID,
 		ImageURL:  imageURL,
 		CreatedAt: post.CreatedAt,
 	}

--- a/backend-go/internal/handler/pet_handler.go
+++ b/backend-go/internal/handler/pet_handler.go
@@ -64,10 +64,6 @@ func (h *PetHandler) Create() fiber.Handler {
 			})
 		}
 
-		// debug
-		log.Info().Msgf("form: %v", form)
-		log.Info().Msgf("form.Value: %v", form.Value)
-
 		// Get form values
 		name := form.Value["name"][0]
 		petType := form.Value["type"][0]
@@ -101,7 +97,7 @@ func (h *PetHandler) Create() fiber.Handler {
 			})
 		}
 
-		pet, err := h.petUsecase.Create(name, petType, species, birthDay, fileKey, userID)
+		_, err = h.petUsecase.Create(name, petType, species, birthDay, fileKey, userID)
 		if err != nil {
 			log.Error().Err(err).Msg("Failed to create pet: failed to create pet")
 			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
@@ -111,7 +107,6 @@ func (h *PetHandler) Create() fiber.Handler {
 
 		return c.JSON(fiber.Map{
 			"message": "Pet created successfully",
-			"pet":     pet,
 		})
 	}
 }


### PR DESCRIPTION
## Summary by Sourcery

Remove optional references and make required edges mandatory across multiple Ent schema models

Bug Fixes:
- Prevent clearing of required edges in update operations
- Add validation checks to ensure required edges are not removed

Enhancements:
- Modify Ent schema to enforce required edges for Comment, FollowRelation, Like, Pet, and Post models
- Remove nullable foreign key references in database schema

Chores:
- Remove SetNillableXXXID methods from generated Ent update and create structs
- Update migration schema to remove nullable constraints on foreign key columns