### PR TITLE
feat: Postにもindex追加

### DIFF
--- a/backend-go/ent/migrate/schema.go
+++ b/backend-go/ent/migrate/schema.go
@@ -119,6 +119,7 @@ var (
 	// PostsColumns holds the columns for the "posts" table.
 	PostsColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeUUID, Unique: true},
+		{Name: "index", Type: field.TypeInt, Unique: true, Nullable: true},
 		{Name: "caption", Type: field.TypeString},
 		{Name: "image_key", Type: field.TypeString},
 		{Name: "created_at", Type: field.TypeTime},
@@ -135,7 +136,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "posts_users_posts",
-				Columns:    []*schema.Column{PostsColumns[7]},
+				Columns:    []*schema.Column{PostsColumns[8]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.NoAction,
 			},

--- a/backend-go/ent/post.go
+++ b/backend-go/ent/post.go
@@ -20,6 +20,8 @@ type Post struct {
 	config `json:"-"`
 	// ID of the ent.
 	ID uuid.UUID `json:"id,omitempty"`
+	// Index holds the value of the "index" field.
+	Index int `json:"index,omitempty"`
 	// Caption holds the value of the "caption" field.
 	Caption string `json:"caption,omitempty"`
 	// ImageKey holds the value of the "image_key" field.
@@ -88,6 +90,8 @@ func (*Post) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case post.FieldTextFeature, post.FieldImageFeature:
 			values[i] = new(pgvector.Vector)
+		case post.FieldIndex:
+			values[i] = new(sql.NullInt64)
 		case post.FieldCaption, post.FieldImageKey:
 			values[i] = new(sql.NullString)
 		case post.FieldCreatedAt, post.FieldDeletedAt:
@@ -116,6 +120,12 @@ func (po *Post) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field id", values[i])
 			} else if value != nil {
 				po.ID = *value
+			}
+		case post.FieldIndex:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field index", values[i])
+			} else if value.Valid {
+				po.Index = int(value.Int64)
 			}
 		case post.FieldCaption:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -211,6 +221,9 @@ func (po *Post) String() string {
 	var builder strings.Builder
 	builder.WriteString("Post(")
 	builder.WriteString(fmt.Sprintf("id=%v, ", po.ID))
+	builder.WriteString("index=")
+	builder.WriteString(fmt.Sprintf("%v", po.Index))
+	builder.WriteString(", ")
 	builder.WriteString("caption=")
 	builder.WriteString(po.Caption)
 	builder.WriteString(", ")

--- a/backend-go/ent/post/post.go
+++ b/backend-go/ent/post/post.go
@@ -15,6 +15,8 @@ const (
 	Label = "post"
 	// FieldID holds the string denoting the id field in the database.
 	FieldID = "id"
+	// FieldIndex holds the string denoting the index field in the database.
+	FieldIndex = "index"
 	// FieldCaption holds the string denoting the caption field in the database.
 	FieldCaption = "caption"
 	// FieldImageKey holds the string denoting the image_key field in the database.
@@ -61,6 +63,7 @@ const (
 // Columns holds all SQL columns for post fields.
 var Columns = []string{
 	FieldID,
+	FieldIndex,
 	FieldCaption,
 	FieldImageKey,
 	FieldCreatedAt,
@@ -91,6 +94,8 @@ func ValidColumn(column string) bool {
 }
 
 var (
+	// IndexValidator is a validator for the "index" field. It is called by the builders before save.
+	IndexValidator func(int) error
 	// CaptionValidator is a validator for the "caption" field. It is called by the builders before save.
 	CaptionValidator func(string) error
 	// ImageKeyValidator is a validator for the "image_key" field. It is called by the builders before save.
@@ -107,6 +112,11 @@ type OrderOption func(*sql.Selector)
 // ByID orders the results by the id field.
 func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
+}
+
+// ByIndex orders the results by the index field.
+func ByIndex(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldIndex, opts...).ToFunc()
 }
 
 // ByCaption orders the results by the caption field.

--- a/backend-go/ent/post/where.go
+++ b/backend-go/ent/post/where.go
@@ -57,6 +57,11 @@ func IDLTE(id uuid.UUID) predicate.Post {
 	return predicate.Post(sql.FieldLTE(FieldID, id))
 }
 
+// Index applies equality check predicate on the "index" field. It's identical to IndexEQ.
+func Index(v int) predicate.Post {
+	return predicate.Post(sql.FieldEQ(FieldIndex, v))
+}
+
 // Caption applies equality check predicate on the "caption" field. It's identical to CaptionEQ.
 func Caption(v string) predicate.Post {
 	return predicate.Post(sql.FieldEQ(FieldCaption, v))
@@ -85,6 +90,56 @@ func TextFeature(v pgvector.Vector) predicate.Post {
 // ImageFeature applies equality check predicate on the "image_feature" field. It's identical to ImageFeatureEQ.
 func ImageFeature(v pgvector.Vector) predicate.Post {
 	return predicate.Post(sql.FieldEQ(FieldImageFeature, v))
+}
+
+// IndexEQ applies the EQ predicate on the "index" field.
+func IndexEQ(v int) predicate.Post {
+	return predicate.Post(sql.FieldEQ(FieldIndex, v))
+}
+
+// IndexNEQ applies the NEQ predicate on the "index" field.
+func IndexNEQ(v int) predicate.Post {
+	return predicate.Post(sql.FieldNEQ(FieldIndex, v))
+}
+
+// IndexIn applies the In predicate on the "index" field.
+func IndexIn(vs ...int) predicate.Post {
+	return predicate.Post(sql.FieldIn(FieldIndex, vs...))
+}
+
+// IndexNotIn applies the NotIn predicate on the "index" field.
+func IndexNotIn(vs ...int) predicate.Post {
+	return predicate.Post(sql.FieldNotIn(FieldIndex, vs...))
+}
+
+// IndexGT applies the GT predicate on the "index" field.
+func IndexGT(v int) predicate.Post {
+	return predicate.Post(sql.FieldGT(FieldIndex, v))
+}
+
+// IndexGTE applies the GTE predicate on the "index" field.
+func IndexGTE(v int) predicate.Post {
+	return predicate.Post(sql.FieldGTE(FieldIndex, v))
+}
+
+// IndexLT applies the LT predicate on the "index" field.
+func IndexLT(v int) predicate.Post {
+	return predicate.Post(sql.FieldLT(FieldIndex, v))
+}
+
+// IndexLTE applies the LTE predicate on the "index" field.
+func IndexLTE(v int) predicate.Post {
+	return predicate.Post(sql.FieldLTE(FieldIndex, v))
+}
+
+// IndexIsNil applies the IsNil predicate on the "index" field.
+func IndexIsNil() predicate.Post {
+	return predicate.Post(sql.FieldIsNull(FieldIndex))
+}
+
+// IndexNotNil applies the NotNil predicate on the "index" field.
+func IndexNotNil() predicate.Post {
+	return predicate.Post(sql.FieldNotNull(FieldIndex))
 }
 
 // CaptionEQ applies the EQ predicate on the "caption" field.

--- a/backend-go/ent/post_create.go
+++ b/backend-go/ent/post_create.go
@@ -28,6 +28,20 @@ type PostCreate struct {
 	conflict []sql.ConflictOption
 }
 
+// SetIndex sets the "index" field.
+func (pc *PostCreate) SetIndex(i int) *PostCreate {
+	pc.mutation.SetIndex(i)
+	return pc
+}
+
+// SetNillableIndex sets the "index" field if the given value is not nil.
+func (pc *PostCreate) SetNillableIndex(i *int) *PostCreate {
+	if i != nil {
+		pc.SetIndex(*i)
+	}
+	return pc
+}
+
 // SetCaption sets the "caption" field.
 func (pc *PostCreate) SetCaption(s string) *PostCreate {
 	pc.mutation.SetCaption(s)
@@ -198,6 +212,11 @@ func (pc *PostCreate) defaults() {
 
 // check runs all checks and user-defined validators on the builder.
 func (pc *PostCreate) check() error {
+	if v, ok := pc.mutation.Index(); ok {
+		if err := post.IndexValidator(v); err != nil {
+			return &ValidationError{Name: "index", err: fmt.Errorf(`ent: validator failed for field "Post.index": %w`, err)}
+		}
+	}
 	if _, ok := pc.mutation.Caption(); !ok {
 		return &ValidationError{Name: "caption", err: errors.New(`ent: missing required field "Post.caption"`)}
 	}
@@ -255,6 +274,10 @@ func (pc *PostCreate) createSpec() (*Post, *sqlgraph.CreateSpec) {
 	if id, ok := pc.mutation.ID(); ok {
 		_node.ID = id
 		_spec.ID.Value = &id
+	}
+	if value, ok := pc.mutation.Index(); ok {
+		_spec.SetField(post.FieldIndex, field.TypeInt, value)
+		_node.Index = value
 	}
 	if value, ok := pc.mutation.Caption(); ok {
 		_spec.SetField(post.FieldCaption, field.TypeString, value)
@@ -336,7 +359,7 @@ func (pc *PostCreate) createSpec() (*Post, *sqlgraph.CreateSpec) {
 // of the `INSERT` statement. For example:
 //
 //	client.Post.Create().
-//		SetCaption(v).
+//		SetIndex(v).
 //		OnConflict(
 //			// Update the row with the new values
 //			// the was proposed for insertion.
@@ -345,7 +368,7 @@ func (pc *PostCreate) createSpec() (*Post, *sqlgraph.CreateSpec) {
 //		// Override some of the fields with custom
 //		// update values.
 //		Update(func(u *ent.PostUpsert) {
-//			SetCaption(v+v).
+//			SetIndex(v+v).
 //		}).
 //		Exec(ctx)
 func (pc *PostCreate) OnConflict(opts ...sql.ConflictOption) *PostUpsertOne {
@@ -487,6 +510,9 @@ func (u *PostUpsertOne) UpdateNewValues() *PostUpsertOne {
 	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(s *sql.UpdateSet) {
 		if _, exists := u.create.mutation.ID(); exists {
 			s.SetIgnore(post.FieldID)
+		}
+		if _, exists := u.create.mutation.Index(); exists {
+			s.SetIgnore(post.FieldIndex)
 		}
 	}))
 	return u
@@ -760,7 +786,7 @@ func (pcb *PostCreateBulk) ExecX(ctx context.Context) {
 //		// Override some of the fields with custom
 //		// update values.
 //		Update(func(u *ent.PostUpsert) {
-//			SetCaption(v+v).
+//			SetIndex(v+v).
 //		}).
 //		Exec(ctx)
 func (pcb *PostCreateBulk) OnConflict(opts ...sql.ConflictOption) *PostUpsertBulk {
@@ -806,6 +832,9 @@ func (u *PostUpsertBulk) UpdateNewValues() *PostUpsertBulk {
 		for _, b := range u.create.builders {
 			if _, exists := b.mutation.ID(); exists {
 				s.SetIgnore(post.FieldID)
+			}
+			if _, exists := b.mutation.Index(); exists {
+				s.SetIgnore(post.FieldIndex)
 			}
 		}
 	}))

--- a/backend-go/ent/post_query.go
+++ b/backend-go/ent/post_query.go
@@ -373,12 +373,12 @@ func (pq *PostQuery) WithLikes(opts ...func(*LikeQuery)) *PostQuery {
 // Example:
 //
 //	var v []struct {
-//		Caption string `json:"caption,omitempty"`
+//		Index int `json:"index,omitempty"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
 //	client.Post.Query().
-//		GroupBy(post.FieldCaption).
+//		GroupBy(post.FieldIndex).
 //		Aggregate(ent.Count()).
 //		Scan(ctx, &v)
 func (pq *PostQuery) GroupBy(field string, fields ...string) *PostGroupBy {
@@ -396,11 +396,11 @@ func (pq *PostQuery) GroupBy(field string, fields ...string) *PostGroupBy {
 // Example:
 //
 //	var v []struct {
-//		Caption string `json:"caption,omitempty"`
+//		Index int `json:"index,omitempty"`
 //	}
 //
 //	client.Post.Query().
-//		Select(post.FieldCaption).
+//		Select(post.FieldIndex).
 //		Scan(ctx, &v)
 func (pq *PostQuery) Select(fields ...string) *PostSelect {
 	pq.ctx.Fields = append(pq.ctx.Fields, fields...)

--- a/backend-go/ent/post_update.go
+++ b/backend-go/ent/post_update.go
@@ -286,6 +286,9 @@ func (pu *PostUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			}
 		}
 	}
+	if pu.mutation.IndexCleared() {
+		_spec.ClearField(post.FieldIndex, field.TypeInt)
+	}
 	if value, ok := pu.mutation.Caption(); ok {
 		_spec.SetField(post.FieldCaption, field.TypeString, value)
 	}
@@ -734,6 +737,9 @@ func (puo *PostUpdateOne) sqlSave(ctx context.Context) (_node *Post, err error) 
 				ps[i](selector)
 			}
 		}
+	}
+	if puo.mutation.IndexCleared() {
+		_spec.ClearField(post.FieldIndex, field.TypeInt)
 	}
 	if value, ok := puo.mutation.Caption(); ok {
 		_spec.SetField(post.FieldCaption, field.TypeString, value)

--- a/backend-go/ent/runtime.go
+++ b/backend-go/ent/runtime.go
@@ -77,16 +77,20 @@ func init() {
 	pet.DefaultID = petDescID.Default.(func() uuid.UUID)
 	postFields := schema.Post{}.Fields()
 	_ = postFields
+	// postDescIndex is the schema descriptor for index field.
+	postDescIndex := postFields[1].Descriptor()
+	// post.IndexValidator is a validator for the "index" field. It is called by the builders before save.
+	post.IndexValidator = postDescIndex.Validators[0].(func(int) error)
 	// postDescCaption is the schema descriptor for caption field.
-	postDescCaption := postFields[1].Descriptor()
+	postDescCaption := postFields[2].Descriptor()
 	// post.CaptionValidator is a validator for the "caption" field. It is called by the builders before save.
 	post.CaptionValidator = postDescCaption.Validators[0].(func(string) error)
 	// postDescImageKey is the schema descriptor for image_key field.
-	postDescImageKey := postFields[2].Descriptor()
+	postDescImageKey := postFields[3].Descriptor()
 	// post.ImageKeyValidator is a validator for the "image_key" field. It is called by the builders before save.
 	post.ImageKeyValidator = postDescImageKey.Validators[0].(func(string) error)
 	// postDescCreatedAt is the schema descriptor for created_at field.
-	postDescCreatedAt := postFields[3].Descriptor()
+	postDescCreatedAt := postFields[4].Descriptor()
 	// post.DefaultCreatedAt holds the default value on creation for the created_at field.
 	post.DefaultCreatedAt = postDescCreatedAt.Default.(func() time.Time)
 	// postDescID is the schema descriptor for id field.

--- a/backend-go/ent/schema/post.go
+++ b/backend-go/ent/schema/post.go
@@ -20,6 +20,7 @@ type Post struct {
 func (Post) Fields() []ent.Field {
 	return []ent.Field{
 		field.UUID("id", uuid.UUID{}).Default(uuid.New).Unique(),
+		field.Int("index").Immutable().NonNegative().Unique().Optional(),
 		field.String("caption").NotEmpty(),
 		field.String("image_key").NotEmpty(),
 		field.Time("created_at").Default(time.Now),

--- a/backend-go/internal/infra/post.go
+++ b/backend-go/internal/infra/post.go
@@ -52,10 +52,16 @@ func (r *PostRepository) CreatePost(caption, userID, fileKey string) (*ent.Post,
 		return nil, err
 	}
 
+	postCount, err := r.db.Post.Query().Count(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
 	post, err := r.db.Post.Create().
 		SetCaption(caption).
 		SetImageKey(fileKey).
 		SetUserID(userUUID).
+		SetIndex(postCount).
 		Save(context.Background())
 	if err != nil {
 		return nil, err

--- a/backend-go/internal/seed/seed.go
+++ b/backend-go/internal/seed/seed.go
@@ -178,27 +178,33 @@ func createPosts(client *ent.Client, users []*ent.User) ([]*ent.Post, error) {
 		client.Post.Create().
 			SetCaption("Max's first day at the park").
 			SetUser(users[0]).
-			SetImageKey(sampleImageKey),
+			SetImageKey(sampleImageKey).
+			SetIndex(0),
 		client.Post.Create().
 			SetCaption("Luna's New Toy").
 			SetUser(users[1]).
-			SetImageKey(sampleImageKey),
+			SetImageKey(sampleImageKey).
+			SetIndex(1),
 		client.Post.Create().
 			SetCaption("Buddy's Birthday Celebration").
 			SetUser(users[2]).
-			SetImageKey(sampleImageKey),
+			SetImageKey(sampleImageKey).
+			SetIndex(2),
 		client.Post.Create().
 			SetCaption("Coco's New Hutch").
 			SetUser(users[3]).
-			SetImageKey(sampleImageKey),
+			SetImageKey(sampleImageKey).
+			SetIndex(3),
 		client.Post.Create().
 			SetCaption("Rocky's First Swimming Lesson").
 			SetUser(users[4]).
-			SetImageKey(sampleImageKey),
+			SetImageKey(sampleImageKey).
+			SetIndex(4),
 		client.Post.Create().
 			SetCaption("Milo's Favorite Napping Spot").
 			SetUser(users[0]).
-			SetImageKey(sampleImageKey),
+			SetImageKey(sampleImageKey).
+			SetIndex(5),
 	}
 
 	return client.Post.CreateBulk(posts...).Save(context.Background())


### PR DESCRIPTION
## Summary by Sourcery

Add an index field to the Post entity to support ordered posts

New Features:
- Introduce an optional index field for Posts that allows ordering and tracking the sequence of posts

Enhancements:
- Update Post creation logic to automatically assign an incremental index
- Add query predicates and mutation methods for the new index field