### PR TITLE
chore: バックエンドのルートの末尾にスラッシュを追加

### DIFF
--- a/backend-go/internal/routes/auth_routes.go
+++ b/backend-go/internal/routes/auth_routes.go
@@ -8,26 +8,26 @@ import (
 // SetupAuthRoutes sets up the auth routes
 func SetupAuthRoutes(app *echo.Echo) {
 	authHandler := injector.InjectAuthHandler()
-	authGroup := app.Group("/auth")
+	authGroup := app.Group("/auth/")
 
 	// Verify email
-	authGroup.POST("/verify-email", authHandler.VerifyEmail)
+	authGroup.POST("/verify-email/", authHandler.VerifyEmail)
 
 	// Sign in
-	authGroup.POST("/signin", authHandler.SignIn)
+	authGroup.POST("/signin/", authHandler.SignIn)
 
 	// Sign up
-	authGroup.POST("/signup", authHandler.SignUp)
+	authGroup.POST("/signup/", authHandler.SignUp)
 
 	// Refresh token
-	authGroup.POST("/refresh", authHandler.RefreshToken)
+	authGroup.POST("/refresh/", authHandler.RefreshToken)
 
 	// Get current user
-	authGroup.GET("/me", authHandler.GetMe)
+	authGroup.GET("/me/", authHandler.GetMe)
 
 	// Sign out
-	authGroup.POST("/signout", authHandler.SignOut)
+	authGroup.POST("/signout/", authHandler.SignOut)
 
 	// Get session
-	authGroup.GET("/session", authHandler.GetSession)
+	authGroup.GET("/session/", authHandler.GetSession)
 }

--- a/backend-go/internal/routes/pet_routes.go
+++ b/backend-go/internal/routes/pet_routes.go
@@ -8,15 +8,15 @@ import (
 // SetupPetRoutes sets up the pet routes
 func SetupPetRoutes(app *echo.Echo) {
 	petHandler := injector.InjectPetHandler()
-	petGroup := app.Group("/pets")
+	petGroup := app.Group("/pets/")
 
 	// Get pets by owner ID
-	petGroup.GET("/owner", petHandler.GetByOwner)
+	petGroup.GET("/owner/", petHandler.GetByOwner)
 
 	// Create a new pet
-	petGroup.POST("/new", petHandler.Create)
+	petGroup.POST("/new/", petHandler.Create)
 
-	petGroup.PUT("/update", petHandler.Update)
+	petGroup.PUT("/update/", petHandler.Update)
 
-	petGroup.DELETE("/delete", petHandler.Delete)
+	petGroup.DELETE("/delete/", petHandler.Delete)
 }

--- a/backend-go/internal/routes/post_routes.go
+++ b/backend-go/internal/routes/post_routes.go
@@ -8,7 +8,7 @@ import (
 // SetupPostRoutes sets up the post routes
 func SetupPostRoutes(app *echo.Echo) {
 	postHandler := injector.InjectPostHandler()
-	postGroup := app.Group("/posts")
+	postGroup := app.Group("/posts/")
 
 	// Get all posts
 	postGroup.GET("/", postHandler.GetAllPosts)

--- a/backend-go/internal/routes/user_routes.go
+++ b/backend-go/internal/routes/user_routes.go
@@ -9,10 +9,15 @@ func SetupUserRoutes(app *echo.Echo) {
 	userHandler := injector.InjectUserHandler()
 	userGroup := app.Group("/users")
 
-	userGroup.PUT("/update", userHandler.UpdateUser)
-	userGroup.POST("/follow", userHandler.Follow)
-	userGroup.GET("/follower_count", userHandler.GetFollowerCount)
-	userGroup.GET("/follows_count", userHandler.GetFollowsCount)
-	userGroup.GET("/follower_users", userHandler.GetFollowerUsers)
-	userGroup.GET("/follows_users", userHandler.GetFollowsUsers)
+	userGroup.PUT("/update/", userHandler.UpdateUser)
+
+	userGroup.POST("/follow/", userHandler.Follow)
+
+	userGroup.GET("/follower_count/", userHandler.GetFollowerCount)
+
+	userGroup.GET("/follows_count/", userHandler.GetFollowsCount)
+
+	userGroup.GET("/follower_users/", userHandler.GetFollowerUsers)
+
+	userGroup.GET("/follows_users/", userHandler.GetFollowsUsers)
 }


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Standardize route definitions by appending trailing slashes to all route groups and endpoints