### PR TITLE
chore: ホームタブタップで画面上部に戻るように

### DIFF
--- a/app-front/app/(tabs)/_layout.tsx
+++ b/app-front/app/(tabs)/_layout.tsx
@@ -7,9 +7,12 @@ import { IconSymbol } from "@/components/ui/IconSymbol";
 import TabBarBackground from "@/components/ui/TabBarBackground";
 import { Colors } from "@/constants/Colors";
 import { useColorScheme } from "@/hooks/useColorScheme";
+import { useHomeTabHandler } from "@/providers/HomeTabScrollContext";
+
 
 export default function TabLayout() {
   const colorScheme = useColorScheme();
+  const { triggerHandler } = useHomeTabHandler();
 
   return (
     <Tabs
@@ -34,6 +37,11 @@ export default function TabLayout() {
             <IconSymbol size={28} name="house.fill" color={color} />
           ),
         }}
+        listeners={{
+          tabPress: () => {
+            triggerHandler();
+          },
+        }}
       />
       <Tabs.Screen
         name="camera"
@@ -57,3 +65,4 @@ export default function TabLayout() {
     </Tabs>
   );
 }
+

--- a/app-front/app/(tabs)/profile.tsx
+++ b/app-front/app/(tabs)/profile.tsx
@@ -43,7 +43,16 @@ const ProfileScreen: React.FC = () => {
 
   const slideAnimProfile = useRef(new Animated.Value(windowWidth)).current;
   const slideAnimPet = useRef(new Animated.Value(windowWidth)).current;
-  const backgroundColor = colorScheme == "light" ? "white" : "black"
+  const backgroundColor = colorScheme == "light" ? "white" : "black";
+
+  const scrollY = useRef(new Animated.Value(0)).current;
+  const HEADER_THRESHOLD = 150;
+
+  const headerOpacity = scrollY.interpolate({
+    inputRange: [HEADER_THRESHOLD - 20, HEADER_THRESHOLD],
+    outputRange: [0, 1],
+    extrapolate: "clamp",
+  });
 
   const handleLogout = async () => {
     try {
@@ -97,9 +106,9 @@ const ProfileScreen: React.FC = () => {
   }
 
   const headerContent = (
-    <>
+    <View style={{backgroundColor}}>
       <ProfileHeader user={user} onLogout={handleLogout} />
-      <View style={styles.editButtonsContainer}>
+      <View style={[styles.editButtonsContainer]}>
         <TouchableOpacity
           style={styles.editButton}
           onPress={openEditProfileModal}
@@ -117,7 +126,7 @@ const ProfileScreen: React.FC = () => {
         selectedTab={selectedTab}
         onSelectTab={setSelectedTab}
       />
-    </>
+    </View>
   );
 
   const contentList =
@@ -128,6 +137,10 @@ const ProfileScreen: React.FC = () => {
         refreshing={authLoading}
         colorScheme={colorScheme}
         headerComponent={headerContent}
+        onScroll={Animated.event(
+          [{ nativeEvent: { contentOffset: { y: scrollY } } }],
+          { useNativeDriver: false }
+        )}
       />
     ) : (
       <UserPostList
@@ -136,14 +149,22 @@ const ProfileScreen: React.FC = () => {
         refreshing={authLoading}
         colorScheme={colorScheme}
         headerComponent={headerContent}
+        onScroll={Animated.event(
+          [{ nativeEvent: { contentOffset: { y: scrollY } } }],
+          { useNativeDriver: false }
+        )}
       />
     );
 
   return (
-    <ThemedView style={[styles.container, {backgroundColor}]}>
-      <View style={styles.topHeader}>
-        <Text style={styles.userName}>{user.name}</Text>
-      </View>
+    <ThemedView style={[styles.container, { backgroundColor }]}>
+      <Animated.View
+        style={[styles.topHeader, { backgroundColor: colors.background }]}
+      >
+        <Animated.Text style={[styles.userName, { opacity: headerOpacity }]}>
+          {user.name}
+        </Animated.Text>
+      </Animated.View>
       {contentList}
       <ProfileEditModal
         visible={isEditModalVisible}
@@ -170,7 +191,7 @@ const getStyles = (colors: typeof Colors.light) =>
       flex: 1,
     },
     topHeader: {
-      paddingTop: 50,
+      paddingTop: 42,
       paddingBottom: 12,
       backgroundColor: colors.background,
       alignItems: "center",

--- a/app-front/app/_layout.tsx
+++ b/app-front/app/_layout.tsx
@@ -16,6 +16,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AuthProvider, useAuth } from "@/providers/AuthContext";
 import { Colors } from "@/constants/Colors";
 import Constants from "expo-constants";
+import { HomeTabScrollProvider } from "@/providers/HomeTabScrollContext";
 
 // SplashScreen が自動で隠れないように設定
 SplashScreen.preventAutoHideAsync();
@@ -84,12 +85,14 @@ export default function RootLayout() {
   return (
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
+      <HomeTabScrollProvider>
         <ThemeProvider
           value={colorScheme === "dark" ? DarkTheme : DefaultTheme}
         >
           <AuthSwitch />
           <StatusBar style="auto" />
         </ThemeProvider>
+        </HomeTabScrollProvider>
       </AuthProvider>
     </QueryClientProvider>
   );

--- a/app-front/components/ProfileHeader.tsx
+++ b/app-front/components/ProfileHeader.tsx
@@ -13,9 +13,10 @@ export const ProfileHeader: React.FC<ProfileHeaderProps> = ({ user, onLogout }) 
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
   const styles = getStyles(colors);
+  const backgroundColor = colorScheme == "light" ? "white" : "black"
 
   return (
-    <View style={styles.headerContainer}>
+    <View style={[styles.headerContainer,{backgroundColor}]}>
       <View style={styles.topRow}>
         <TouchableOpacity onPress={onLogout}>
           <Text style={styles.logoutText}>ログアウト</Text>

--- a/app-front/components/ProfileTabSelector.tsx
+++ b/app-front/components/ProfileTabSelector.tsx
@@ -13,10 +13,11 @@ type ProfileTabSelectorProps = {
 export const ProfileTabSelector: React.FC<ProfileTabSelectorProps> = ({ selectedTab, onSelectTab }) => {
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
+  const backgroundColor = colorScheme == "light" ? "white" : "black"
   const styles = getStyles(colors);
 
   return (
-    <View style={styles.tabContainer}>
+    <View style={[styles.tabContainer, {backgroundColor }]}>
       <TouchableOpacity
         onPress={() => onSelectTab('posts')}
         style={[styles.tabButton, selectedTab === 'posts' && styles.tabButtonActive]}

--- a/app-front/components/UserPetsList.tsx
+++ b/app-front/components/UserPetsList.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { FlatList, RefreshControl, Text, View, StyleSheet, useColorScheme } from "react-native";
+import {
+  FlatList,
+  RefreshControl,
+  Text,
+  View,
+  useColorScheme,
+} from "react-native";
 import PetPanel from "@/components/PetPanel";
 import { Pet } from "@/constants/api";
 import { Colors } from "@/constants/Colors";
@@ -10,9 +16,17 @@ type Props = {
   onRefresh: () => void;
   colorScheme: ReturnType<typeof useColorScheme>;
   headerComponent: React.JSX.Element;
+  onScroll?: (event: any) => void;
 };
 
-export const UserPetList: React.FC<Props> = ({ pets, refreshing, onRefresh, colorScheme, headerComponent }) => {
+export const UserPetList: React.FC<Props> = ({
+  pets,
+  refreshing,
+  onRefresh,
+  colorScheme,
+  headerComponent,
+  onScroll,
+}) => {
   const colors = Colors[colorScheme ?? "light"];
   const backgroundColor = colorScheme === "dark" ? "black" : "white";
 
@@ -33,7 +47,13 @@ export const UserPetList: React.FC<Props> = ({ pets, refreshing, onRefresh, colo
           tintColor={colorScheme === "light" ? "black" : "white"}
         />
       }
-      ListHeaderComponent={headerComponent}
+      onScroll={onScroll}
+      scrollEventThrottle={16}
+      ListHeaderComponent={
+        <View style={{ backgroundColor: colors.background }}>
+          {headerComponent}
+        </View>
+      }
       contentContainerStyle={{
         flexGrow: 1,
         backgroundColor,

--- a/app-front/components/UserPostList.tsx
+++ b/app-front/components/UserPostList.tsx
@@ -1,5 +1,13 @@
 import React from "react";
-import { FlatList, RefreshControl, Text, StyleSheet, useColorScheme } from "react-native";
+import {
+  FlatList,
+  RefreshControl,
+  Text,
+  StyleSheet,
+  useColorScheme,
+  View,
+  Animated,
+} from "react-native";
 import ProfilePostPanel from "@/components/ProfilePostPanel";
 import { Post } from "@/components/PostPanel";
 import { Colors } from "@/constants/Colors";
@@ -10,11 +18,19 @@ type Props = {
   onRefresh: () => void;
   colorScheme: ReturnType<typeof useColorScheme>;
   headerComponent: React.JSX.Element;
+  onScroll?: (event: any) => void;
 };
 
-export const UserPostList: React.FC<Props> = ({ posts, refreshing, onRefresh, colorScheme, headerComponent }) => {
+export const UserPostList: React.FC<Props> = ({
+  posts,
+  refreshing,
+  onRefresh,
+  colorScheme,
+  headerComponent,
+  onScroll,
+}) => {
   const colors = Colors[colorScheme ?? "light"];
-  const backgroundColor = colorScheme == "light" ? "white" : "black"
+  const backgroundColor = colorScheme === "light" ? "white" : "black";
 
   return (
     <FlatList
@@ -34,8 +50,14 @@ export const UserPostList: React.FC<Props> = ({ posts, refreshing, onRefresh, co
           tintColor={colorScheme === "light" ? "black" : "white"}
         />
       }
-      ListHeaderComponent={headerComponent}
-      contentContainerStyle={{ flexGrow: 1, paddingBottom: 20, backgroundColor }}
+      onScroll={onScroll}
+      scrollEventThrottle={16}
+      ListHeaderComponent={
+        <View style={{ backgroundColor: colors.background }}>
+          {headerComponent}
+        </View>
+      }
+      contentContainerStyle={{ flexGrow: 1, backgroundColor, paddingBottom: 20 }}
       ListEmptyComponent={
         <Text style={{ color: colors.text, textAlign: "center", marginTop: 32 }}>
           投稿しましょう！

--- a/app-front/providers/HomeTabScrollContext.tsx
+++ b/app-front/providers/HomeTabScrollContext.tsx
@@ -1,0 +1,34 @@
+import React, { createContext, useContext, useRef } from "react";
+
+type HomeTabScrollContextType = {
+  setHandler: (handler: () => void) => void;
+  triggerHandler: () => void;
+};
+
+const HomeTabScrollContext = createContext<HomeTabScrollContextType | undefined>(undefined);
+
+export const HomeTabScrollProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const handlerRef = useRef<(() => void) | null>(null);
+
+  const setHandler = (handler: () => void) => {
+    handlerRef.current = handler;
+  };
+
+  const triggerHandler = () => {
+    handlerRef.current?.();
+  };
+
+  return (
+    <HomeTabScrollContext.Provider value={{ setHandler, triggerHandler }}>
+      {children}
+    </HomeTabScrollContext.Provider>
+  );
+};
+
+export const useHomeTabHandler = () => {
+  const context = useContext(HomeTabScrollContext);
+  if (!context) {
+    throw new Error("useHomeTabHandler must be used within HomeTabScrollProvider");
+  }
+  return context;
+};


### PR DESCRIPTION
## Summary by Sourcery

Implement a home tab scroll behavior that returns to the top of the screen when tapping the home tab, with additional UI improvements for profile and posts screens

New Features:
- Add a context provider to handle home tab scroll behavior across the app
- Implement scroll-to-top functionality when tapping the home tab

Enhancements:
- Add animated header opacity for profile screen
- Improve scroll event handling in user post and pet lists
- Enhance tab navigation with scroll reset functionality

Chores:
- Refactor component styles and scroll event management
- Add new context provider for home tab scroll handling